### PR TITLE
Feature eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+build/*
+**/tests/casperjs/**/*.js
+**/*min.js
+!node_modules/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,7 @@
+etc/*
+node/*
 build/*
+META-INF/*
 **/tests/casperjs/**/*.js
 **/*min.js
 !node_modules/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: [
+    "./node_modules/@geppettoengine/geppetto-client/.eslintrc.js",
+  ],
+};

--- a/ComponentsInitialization.js
+++ b/ComponentsInitialization.js
@@ -9,71 +9,74 @@ jQuery(function () {
 
   // Enable local storage
   G.enableLocalStorage(false);
-  
-    window.voltage_color = function(x) {
-        x = (x+0.07)/0.1; // normalization
-        if (x < 0) { x = 0; }
-        if (x > 1) { x = 1; }
-        if (x < 0.25) {
-            return [0, x*4, 1];
-        } else if (x < 0.5) {
-            return [0, 1, (1-(x-0.25)*4)];
-        } else if (x < 0.75) {
-            return [(x-0.5)*4, 1, 0];
-        } else {
-            return [1, (1-(x-0.75)*4), 0];
-        }
+  window.voltage_color = function (x) {
+    x = (x + 0.07) / 0.1; // normalization
+    if (x < 0) {
+      x = 0; 
+    }
+    if (x > 1) {
+      x = 1; 
+    }
+    if (x < 0.25) {
+      return [0, x * 4, 1];
+    } else if (x < 0.5) {
+      return [0, 1, (1 - (x - 0.25) * 4)];
+    } else if (x < 0.75) {
+      return [(x - 0.5) * 4, 1, 0];
+    } else {
+      return [1, (1 - (x - 0.75) * 4), 0];
+    }
+  };
+
+  // Canvas initialisation
+  GEPPETTO.ComponentFactory.addComponent('CANVAS', {}, document.getElementById("sim"), function () {
+    this.displayAllInstances();
+  });
+    
+  // Logo initialization
+  GEPPETTO.ComponentFactory.addComponent('LOGO', { logo: 'gpt-gpt_logo' }, document.getElementById("geppettologo"));
+
+  // Logo initialization
+  GEPPETTO.ComponentFactory.addComponent('LINKBUTTON', { left: 41, top: 390, icon: 'fa-github', url: 'https://github.com/openworm/org.geppetto' }, document.getElementById("github-logo"));
+
+  // Control panel initialization
+  GEPPETTO.ComponentFactory.addComponent('CONTROLPANEL', {
+    useBuiltInFilters: true,
+    enablePagination:true,
+    resultsPerPage: 10
+  }, document.getElementById("controlpanel"),
+  function () {
+    // whatever gets passed we keep
+    var passThroughDataFilter = function (entities) {
+      return entities;
     };
 
-  //Canvas initialisation
-  GEPPETTO.ComponentFactory.addComponent('CANVAS', {}, document.getElementById("sim"), function () {
-          this.displayAllInstances();
-      });
-    
-  //Logo initialization
-  GEPPETTO.ComponentFactory.addComponent('LOGO', {logo: 'gpt-gpt_logo'}, document.getElementById("geppettologo"));
-
-  //Logo initialization
-  GEPPETTO.ComponentFactory.addComponent('LINKBUTTON', { left: 41, top: 390, icon: 'fa-github', url: 'https://github.com/openworm/org.geppetto'}, document.getElementById("github-logo"));
-
-      //Control panel initialization
-      GEPPETTO.ComponentFactory.addComponent('CONTROLPANEL', {
-              useBuiltInFilters: true,
-              enablePagination:true,
-              resultsPerPage: 10
-      }, document.getElementById("controlpanel"),
-          function () {
-          // whatever gets passed we keep
-          var passThroughDataFilter = function (entities) {
-              return entities;
-          };
-
-          // set data filter
-          GEPPETTO.ControlPanel.setDataFilter(passThroughDataFilter);
-      });
+    // set data filter
+    GEPPETTO.ControlPanel.setDataFilter(passThroughDataFilter);
+  });
 
 
-  //Spotlight initialization
-  GEPPETTO.ComponentFactory.addComponent('SPOTLIGHT', {}, document.getElementById("spotlight"), function(){
+  // Spotlight initialization
+  GEPPETTO.ComponentFactory.addComponent('SPOTLIGHT', {}, document.getElementById("spotlight"), function (){
     GEPPETTO.Spotlight.addSuggestion(GEPPETTO.Spotlight.plotSample, GEPPETTO.Resources.PLAY_FLOW);
   });
 
-  //Foreground initialization
-  GEPPETTO.ComponentFactory.addComponent('FOREGROUND', {dropDown : false}, document.getElementById("foreground-toolbar"));
+  // Foreground initialization
+  GEPPETTO.ComponentFactory.addComponent('FOREGROUND', { dropDown : false }, document.getElementById("foreground-toolbar"));
 
-  //Console and Experiments table initialization
-  GEPPETTO.ComponentFactory.addComponent('DRAWER', {children: [Console, ExperimentsTable], labels: ["Console", "Experiments"], iconClass: ["fa fa-terminal", "fa fa-flask"]}, document.getElementById("footerHeader"));
+  // Console and Experiments table initialization
+  GEPPETTO.ComponentFactory.addComponent('DRAWER', { children: [Console, ExperimentsTable], labels: ["Console", "Experiments"], iconClass: ["fa fa-terminal", "fa fa-flask"] }, document.getElementById("footerHeader"));
 
-  //Home button initialization
+  // Home button initialization
   GEPPETTO.ComponentFactory.addComponent('HOME', {}, document.getElementById("HomeButton"));
   
-  //Save initialization
+  // Save initialization
   GEPPETTO.ComponentFactory.addComponent('SAVECONTROL', {}, document.getElementById("SaveButton"));
 
-  //Simulation controls initialization
+  // Simulation controls initialization
   GEPPETTO.ComponentFactory.addComponent('SIMULATIONCONTROLS', {}, document.getElementById("sim-toolbar"));
 
-  //Share controls initialization
-  GEPPETTO.ComponentFactory.addComponent('SHARE', {}, document.getElementById("share-button"));		
+  // Share controls initialization
+  GEPPETTO.ComponentFactory.addComponent('SHARE', {}, document.getElementById("share-button"));
   
 });

--- a/GEPPETTO.Backend.js
+++ b/GEPPETTO.Backend.js
@@ -1,1 +1,40 @@
-WEB-INF
+var express = require('express');
+var velocity = require("velocity.java");
+var app = express();
+var expressWs = require('express-ws')(app)
+
+// Redirection for static content
+app.use('/org.geppetto.frontend/geppetto', express.static(__dirname + '/'));
+
+// Web handler
+app.get('/org.geppetto.frontend/geppetto', function (req, res) {
+  velocity.renderOnce("geppetto.vm", {}, "build/", function (err, data) {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    res.send(data.toString());
+  });
+
+});
+
+// Creating web socket
+app.ws('/org.geppetto.frontend/GeppettoServlet', function (ws, req) {
+  ws.on('message', function (msg) {
+    var msgParsed = JSON.parse(msg);
+    if (msgParsed['type'] == 'geppetto_version'){
+      // Where do we get the geppetto version from?
+      console.log("Geppetto Version...")
+      ws.send(JSON.stringify({ "requestID":msgParsed['requestID'],"type":"geppetto_version","data":"{\"geppetto_version\":\"0.3.4\"}" }));
+    }
+  });
+
+  console.log("Opening ws...")
+  ws.send(JSON.stringify({ "type":"client_id","data":"{\"clientID\":\"Connection161\"}" }));
+});
+
+app.listen(8080, function () {
+  console.log('Geppetto listening on port 8080!');
+});
+
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Geppetto Application
 
+[![Build Status](https://travis-ci.org/openworm/geppetto-application.svg?branch=feature-split_dependencies)](https://travis-ci.org/openworm/geppetto-application)
+
 This module contains a template to create Geppetto applications.
 
 ### Quick start

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This module contains a template to create Geppetto applications.
 - Edit `ComponentInitialization.js` to bring your App.js custom file.
 - Create a bundle file by runing `npm run build-dev-noTest`.
 
-#### If you want to install Geppetto client in development mode, follow this steps:
+#### If you want to install Geppetto client in development mode, follow these steps:
 
 - Clone [geppetto-client](https://github.com/openworm/geppetto-client.git).
 - Run `npm install` inside `geppetto-client`.

--- a/package.json
+++ b/package.json
@@ -5,16 +5,18 @@
   "repository": "http://git.geppetto.org",
   "license": "MIT",
   "scripts": {
-    "lint-client": "eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js",
-    "lint-app": "eslint --ignore-pattern 'node_modules/*' .",
-    "build": "npm run lint && webpack -p --progress",
+    "prebuild": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "build": "webpack -p --progress",
+    "prebuild-dev": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev": "webpack --devtool eval",
-    "build-dev-noTest": "npm run lint-client ; npm run lint-app ; webpack --devtool source-map --env.noTest=true",
+    "prebuild-dev-noTest": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "build-dev-noTest": "webpack --devtool source-map --env.noTest=true",
+    "prebuild-dev-noTest:watch": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev-noTest:watch": "webpack --devtool source-map --env.noTest=true --progress --watch",
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },
   "devDependencies": {
-    "@geppettoengine/geppetto-client": "openworm/geppetto-client#lint"
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#feature-eslint"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/package.json
+++ b/package.json
@@ -5,14 +5,16 @@
   "repository": "http://git.geppetto.org",
   "license": "MIT",
   "scripts": {
-    "build": "webpack -p --progress",
+    "lint-client": "eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js",
+    "lint-app": "eslint --ignore-pattern 'node_modules/*' .",
+    "build": "npm run lint && webpack -p --progress",
     "build-dev": "webpack --devtool eval",
-    "build-dev-noTest": "webpack --devtool source-map --env.noTest=true",
+    "build-dev-noTest": "npm run lint-client ; npm run lint-app ; webpack --devtool source-map --env.noTest=true",
     "build-dev-noTest:watch": "webpack --devtool source-map --env.noTest=true --progress --watch",
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },
   "devDependencies": {
-    "@geppettoengine/geppetto-client": "0.0.6"
+    "@geppettoengine/geppetto-client": "openworm/geppetto-client#lint"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/tests/casperjs/DefaultProjectsTests.js
+++ b/tests/casperjs/DefaultProjectsTests.js
@@ -1,112 +1,134 @@
-casper.test.begin('Geppetto default projects tests', function suite(test) {
-	casper.options.viewportSize = {
-			width: 1340,
-			height: 768
-	};
+casper.test.begin('Geppetto default projects tests', function suite (test) {
+  casper.options.viewportSize = {
+    width: 1340,
+    height: 768
+  };
 
-	casper.on("page.error", function(msg, trace) {
-		this.echo("Error: " + msg, "ERROR");
-	});
+  casper.on("page.error", function (msg, trace) {
+    this.echo("Error: " + msg, "ERROR");
+  });
 
-	// show page level errors
-	casper.on('resource.received', function (resource) {
-		var status = resource.status;
-		if (status >= 400) {
-			this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
-		}
-	});
+  // show page level errors
+  casper.on('resource.received', function (resource) {
+    var status = resource.status;
+    if (status >= 400) {
+      this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
+    }
+  });
 
-	casper.start(urlBase+"org.geppetto.frontend", function () {
-		this.echo(urlBase+baseFollowUp+hhcellProject);
-		this.waitForSelector('div[project-id="1"]', function () {
-			this.echo("I've waited for the projects to load.");
-			test.assertExists('div#logo', "logo is found");
-			test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
-			test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
-			test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
-			test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
-			test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
-			test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
-			test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
-			test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
-			test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
-			test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
-		}, null, 3000);
-	});
+  casper.start(urlBase + "org.geppetto.frontend", function () {
+    this.echo(urlBase + baseFollowUp + hhcellProject);
+    this.waitForSelector('div[project-id="1"]', function () {
+      this.echo("I've waited for the projects to load.");
+      test.assertExists('div#logo', "logo is found");
+      test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
+      test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
+      test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
+      test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
+      test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
+      test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
+      test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
+      test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
+      test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
+      test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
+    }, null, 3000);
+  });
 
-	/**Tests SingleComponentHH project**/
-	casper.thenOpen(urlBase+baseFollowUp+hhcellProject,function() {
-		casper.then(function(){testSingleCompononetHHProject(test);});
-	});
+  /** Tests SingleComponentHH project**/
+  casper.thenOpen(urlBase + baseFollowUp + hhcellProject,function () {
+    casper.then(function (){
+      testSingleCompononetHHProject(test);
+    });
+  });
 
-	/**Tests Acnet project**/
-	casper.thenOpen(urlBase+baseFollowUp+acnetProject,function() {
-		casper.then(function(){testACNET2Project(test);});
-	});
+  /** Tests Acnet project**/
+  casper.thenOpen(urlBase + baseFollowUp + acnetProject,function () {
+    casper.then(function (){
+      testACNET2Project(test);
+    });
+  });
 
-	/**Tests C302 project**/
-	casper.thenOpen(urlBase+baseFollowUp+c302Project,function() {
-		casper.then(function(){testC302NetworkProject(test);});
-	});
+  /** Tests C302 project**/
+  casper.thenOpen(urlBase + baseFollowUp + c302Project,function () {
+    casper.then(function (){
+      testC302NetworkProject(test);
+    });
+  });
 
-	/**Tests CA1 project**/
-	casper.thenOpen(urlBase+baseFollowUp+ca1Project,function() {
-		casper.then(function(){ca1Test(test);});
-	});
+  /** Tests CA1 project**/
+  casper.thenOpen(urlBase + baseFollowUp + ca1Project,function () {
+    casper.then(function (){
+      ca1Test(test);
+    });
+  });
 
-	/**Tests EyeWire project**/
-	casper.thenOpen(urlBase+baseFollowUp+eyeWire,function() {
-		casper.then(function(){launchTest(test,"EyeWireGanglionCell",45000);});
-	});
+  /** Tests EyeWire project**/
+  casper.thenOpen(urlBase + baseFollowUp + eyeWire,function () {
+    casper.then(function (){
+      launchTest(test,"EyeWireGanglionCell",45000);
+    });
+  });
 
-	/**Tests Pharyngeal project**/
-	casper.thenOpen(urlBase+baseFollowUp+Pharyngeal,function() {
-		casper.then(function(){pharyngealTest(test);});
-	});
+  /** Tests Pharyngeal project**/
+  casper.thenOpen(urlBase + baseFollowUp + Pharyngeal,function () {
+    casper.then(function (){
+      pharyngealTest(test);
+    });
+  });
 
-	/**Tests cElegansConnectome project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansConnectome,function() {
-		casper.then(function(){testC302Connectome(test);});
-	});
+  /** Tests cElegansConnectome project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansConnectome,function () {
+    casper.then(function (){
+      testC302Connectome(test);
+    });
+  });
 
-	/**Tests cElegansMuscleModel project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansMuscleModel,function() {
-		casper.then(function(){testPMuscleCellProject(test);});
-	});
+  /** Tests cElegansMuscleModel project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansMuscleModel,function () {
+    casper.then(function (){
+      testPMuscleCellProject(test);
+    });
+  });
 
-	/**Tests cElegansPVDR project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansPVDR,function() {
-		casper.then(function(){testPVDRNeuronProject(test);});
-	});
+  /** Tests cElegansPVDR project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansPVDR,function () {
+    casper.then(function (){
+      testPVDRNeuronProject(test);
+    });
+  });
 
-        /**Tests cylinders project**/
-	casper.thenOpen(urlBase+baseFollowUp+cylinders,function() {
-		casper.then(function(){testCylindersProject(test);});
-	});
+  /** Tests cylinders project**/
+  casper.thenOpen(urlBase + baseFollowUp + cylinders,function () {
+    casper.then(function (){
+      testCylindersProject(test);
+    });
+  });
 
-	casper.run(function() {
-		test.done();
-	});
+  casper.run(function () {
+    test.done();
+  });
 });
 
-function pharyngealTest(test){
-	casper.then(function(){launchTest(test,"Pharyngeal",45000);});
-	casper.then(function () {
-		casper.echo("Opening controls panel");
-		buttonClick("#controlPanelBtn");
-	});
+function pharyngealTest (test){
+  casper.then(function (){
+    launchTest(test,"Pharyngeal",45000);
+  });
+  casper.then(function () {
+    casper.echo("Opening controls panel");
+    buttonClick("#controlPanelBtn");
+  });
 
-	casper.then(function(){
-		testInitialControlPanelValues(test,10);
-	});
+  casper.then(function (){
+    testInitialControlPanelValues(test,10);
+  });
 }
 
-function nwbSampleTest(test){
-	casper.waitForSelector('div[id="Popup1"]', function() {
-		this.echo("I've waited for Popup1 to load.");
+function nwbSampleTest (test){
+  casper.waitForSelector('div[id="Popup1"]', function () {
+    this.echo("I've waited for Popup1 to load.");
 
-		this.waitForSelector('div[id="Popup2"]', function() {
-			this.echo("I've waited for Popup2 component to load.");
-		});
-	}, null, 30000);
+    this.waitForSelector('div[id="Popup2"]', function () {
+      this.echo("I've waited for Popup2 component to load.");
+    });
+  }, null, 30000);
 }

--- a/tests/casperjs/GeppettoModelTests.js
+++ b/tests/casperjs/GeppettoModelTests.js
@@ -1,206 +1,228 @@
-casper.test.begin('Geppetto Model Factory and Injected Capabilities Tests', function suite(test) {
-	casper.options.viewportSize = {
-			width: 1340,
-			height: 768
-	};
+casper.test.begin('Geppetto Model Factory and Injected Capabilities Tests', function suite (test) {
+  casper.options.viewportSize = {
+    width: 1340,
+    height: 768
+  };
 
-	casper.on("page.error", function(msg, trace) {
-		this.echo("Error: " + msg, "ERROR");
-	});
+  casper.on("page.error", function (msg, trace) {
+    this.echo("Error: " + msg, "ERROR");
+  });
 
-	// show page level errors
-	casper.on('resource.received', function (resource) {
-		var status = resource.status;
-		if (status >= 400) {
-			this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
-		}
-	});
+  // show page level errors
+  casper.on('resource.received', function (resource) {
+    var status = resource.status;
+    if (status >= 400) {
+      this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
+    }
+  });
 
-	casper.start(urlBase+"org.geppetto.frontend", function () {
-		this.echo(urlBase+baseFollowUp+hhcellProject);
-		//testing with project ACNET
-		this.waitForSelector('div[project-id="5"]', function () {
-			this.echo("I've waited for the projects to load.");
-			test.assertExists('div#logo', "logo is found");
-			test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle present");
-		}, null, 3000);
-	});
+  casper.start(urlBase + "org.geppetto.frontend", function () {
+    this.echo(urlBase + baseFollowUp + hhcellProject);
+    // testing with project ACNET
+    this.waitForSelector('div[project-id="5"]', function () {
+      this.echo("I've waited for the projects to load.");
+      test.assertExists('div#logo', "logo is found");
+      test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle present");
+    }, null, 3000);
+  });
 
-	/**Tests model factory and injected capabilities using Primary Auditory Cortex Network project**/
-	casper.thenOpen(urlBase+baseFollowUp+acnetProject,function() {
-		casper.then(function(){testUsingSingleCompononetHHProject(test);});
-	});
+  /** Tests model factory and injected capabilities using Primary Auditory Cortex Network project**/
+  casper.thenOpen(urlBase + baseFollowUp + acnetProject,function () {
+    casper.then(function (){
+      testUsingSingleCompononetHHProject(test);
+    });
+  });
 
-	casper.run(function() {
-		test.done();
-	});
+  casper.run(function () {
+    test.done();
+  });
 });
 
 /**
  * Tests model factory and injected capabilities using the  Primary Auditory Cortex Network project.
  */
-function testUsingSingleCompononetHHProject(test){
-	casper.then(function(){launchTest(test,"Primary Auditory Cortex Network",30000);});
-	casper.echo("------------STARTING ACNET TEST--------------");
-	casper.then(function(){removeAllPlots();});
+function testUsingSingleCompononetHHProject (test){
+  casper.then(function (){
+    launchTest(test,"Primary Auditory Cortex Network",30000);
+  });
+  casper.echo("------------STARTING ACNET TEST--------------");
+  casper.then(function (){
+    removeAllPlots();
+  });
 
-	/*Start Testing Model Factory*/
-	casper.echo("----Start Testing Model Factory----");
-	casper.then(function () {
-		var modelDefined = casper.evaluate(function() {return window.Model != undefined;});
-		test.assertEquals(modelDefined, true, "Model is not undefined");
-	});
+  /* Start Testing Model Factory*/
+  casper.echo("----Start Testing Model Factory----");
+  casper.then(function () {
+    var modelDefined = casper.evaluate(function () {
+      return window.Model != undefined;
+    });
+    test.assertEquals(modelDefined, true, "Model is not undefined");
+  });
 
-	casper.then(function () {
-		var modelVariables = casper.evaluate(function() {return window.Model.getVariables().length;});
-		test.assertEquals(modelVariables, 2, "2 Variables as expected");
-	});
+  casper.then(function () {
+    var modelVariables = casper.evaluate(function () {
+      return window.Model.getVariables().length;
+    });
+    test.assertEquals(modelVariables, 2, "2 Variables as expected");
+  });
 
-	casper.then(function () {
-		var modelLibraries = casper.evaluate(function() {return window.Model.getLibraries().length;});
-		test.assertEquals(modelLibraries, 2, "2 Libraries as expected");
-	});
+  casper.then(function () {
+    var modelLibraries = casper.evaluate(function () {
+      return window.Model.getLibraries().length;
+    });
+    test.assertEquals(modelLibraries, 2, "2 Libraries as expected");
+  });
 
-	casper.then(function () {
-		var modelInstanceDefined = casper.evaluate(function() {return window.Instances != undefined;});
-		test.assertEquals(modelInstanceDefined, true, "Instances are not undefined");
-	});
+  casper.then(function () {
+    var modelInstanceDefined = casper.evaluate(function () {
+      return window.Instances != undefined;
+    });
+    test.assertEquals(modelInstanceDefined, true, "Instances are not undefined");
+  });
 
-	casper.then(function () {
-		var modelTopLevelInstances = casper.evaluate(function() {return window.Instances.length;});
-		test.assertEquals(modelTopLevelInstances, 2, "2 top level instance as expected");
-	});
+  casper.then(function () {
+    var modelTopLevelInstances = casper.evaluate(function () {
+      return window.Instances.length;
+    });
+    test.assertEquals(modelTopLevelInstances, 2, "2 top level instance as expected");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.acnet2 != undefined && window.acnet2.baskets_12 != undefined;
-		}, "Shortcuts created as expected. Tested with acnet and acnet.baskets_12");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.acnet2 != undefined && window.acnet2.baskets_12 != undefined;
+    }, "Shortcuts created as expected. Tested with acnet and acnet.baskets_12");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.acnet2.pyramidals_48.getChildren().length === 48 && window.acnet2.baskets_12.getChildren().length === 12;
-		},"Visual types exploded into instances as expected. Tested with acnet2.pyramidals_48 and acnet2.baskets_12");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.acnet2.pyramidals_48.getChildren().length === 48 && window.acnet2.baskets_12.getChildren().length === 12;
+    },"Visual types exploded into instances as expected. Tested with acnet2.pyramidals_48 and acnet2.baskets_12");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return GEPPETTO.ModelFactory.resolve('//@libraries.1/@types.5').getId() == window.Model.getLibraries()[1].getTypes()[5].getId() &&
-			GEPPETTO.ModelFactory.resolve('//@libraries.1/@types.5').getMetaType() == window.Model.getLibraries()[1].getTypes()[5].getMetaType();
-		},"Ref string resolved to Type as expected. Tested with referencef : //@libraries.1/@types.5");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return GEPPETTO.ModelFactory.resolve('//@libraries.1/@types.5').getId() == window.Model.getLibraries()[1].getTypes()[5].getId()
+      && GEPPETTO.ModelFactory.resolve('//@libraries.1/@types.5').getMetaType() == window.Model.getLibraries()[1].getTypes()[5].getMetaType();
+    },"Ref string resolved to Type as expected. Tested with referencef : //@libraries.1/@types.5");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return acnet2.baskets_12[0].getTypes().length == 1 &&
-			acnet2.baskets_12[0].getTypes()[0].getId() ==  'bask' &&
-			acnet2.baskets_12[0].getTypes()[0].getMetaType() == 'CompositeType';
-		},"Type in the model resolved as expected. Tested with acnet2.baskets_12[0]");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.baskets_12[0].getTypes().length == 1
+      && acnet2.baskets_12[0].getTypes()[0].getId() == 'bask'
+      && acnet2.baskets_12[0].getTypes()[0].getMetaType() == 'CompositeType';
+    },"Type in the model resolved as expected. Tested with acnet2.baskets_12[0]");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups().length == 3 &&
-			acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[0].getId() == 'Cell_Regions' &&
-			(acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[1].getId() == 'Kdr_bask' ||
-					acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[1].getId() == 'Kdr_bask') &&
-					(acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[2].getId() == 'Na_bask' ||
-							acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[2].getId() == 'Na_bask');
-		},'Visual groups created as expected. Tested with acnet2.baskets_12[0]');
-	});	
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups().length == 3
+      && acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[0].getId() == 'Cell_Regions'
+      && (acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[1].getId() == 'Kdr_bask'
+      || acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[1].getId() == 'Kdr_bask')
+      && (acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[2].getId() == 'Na_bask'
+      || acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups()[2].getId() == 'Na_bask');
+    },'Visual groups created as expected. Tested with acnet2.baskets_12[0]');
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType()).length == 12 &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType().getPath()).length == 12 &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType())[0].getId() == "baskets_12[0]" &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType())[0].getMetaType() == "ArrayElementInstance";
-		}, 'getAllInstanceOf returning instances as expected for Type and Type path. Tested with acnet2.baskets_12[0]');
-	});	
+  casper.then(function () {
+    test.assertEval(function () {
+      return GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType()).length == 12
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType().getPath()).length == 12
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType())[0].getId() == "baskets_12[0]"
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getType())[0].getMetaType() == "ArrayElementInstance";
+    }, 'getAllInstanceOf returning instances as expected for Type and Type path. Tested with acnet2.baskets_12[0]');
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable()).length == 1 &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable().getPath()).length == 1 &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable())[0].getId() == "baskets_12" &&
-			GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable())[0].getMetaType() == "ArrayInstance";
-		},'getAllInstanceOf returning instances as expected for Variable and Variable path. Tested with acnet2.baskets_12[0]');
-	});	
+  casper.then(function () {
+    test.assertEval(function () {
+      return GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable()).length == 1
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable().getPath()).length == 1
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable())[0].getId() == "baskets_12"
+      && GEPPETTO.ModelFactory.getAllInstancesOf(acnet2.baskets_12[0].getVariable())[0].getMetaType() == "ArrayInstance";
+    },'getAllInstanceOf returning instances as expected for Variable and Variable path. Tested with acnet2.baskets_12[0]');
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return GEPPETTO.ModelFactory.allPathsIndexing.length == 9741 &&
-			GEPPETTO.ModelFactory.allPathsIndexing[0].path == 'acnet2' &&
-			GEPPETTO.ModelFactory.allPathsIndexing[0].metaType == 'CompositeType' &&
-			GEPPETTO.ModelFactory.allPathsIndexing[9741 - 1].path == "acnet2.SmallNet_bask_bask.GABA_syn_inh.GABA_syn_inh" &&
-			GEPPETTO.ModelFactory.allPathsIndexing[9741 - 1].metaType == 'StateVariableType';
-		},"All potential instance paths exploded as expected");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return GEPPETTO.ModelFactory.allPathsIndexing.length == 9741
+      && GEPPETTO.ModelFactory.allPathsIndexing[0].path == 'acnet2'
+      && GEPPETTO.ModelFactory.allPathsIndexing[0].metaType == 'CompositeType'
+      && GEPPETTO.ModelFactory.allPathsIndexing[9741 - 1].path == "acnet2.SmallNet_bask_bask.GABA_syn_inh.GABA_syn_inh"
+      && GEPPETTO.ModelFactory.allPathsIndexing[9741 - 1].metaType == 'StateVariableType';
+    },"All potential instance paths exploded as expected");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v').length == 456 &&
-			GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[0] == 'acnet2.pyramidals_48[0].soma_0.v' &&
-			GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[333] == 'acnet2.pyramidals_48[45].basal0_6.v' &&
-			GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[456 - 1] == 'acnet2.baskets_12[11].dend_1.v';
-		},"getAllPotentialInstancesEndingWith .v returning expected paths");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v').length == 456
+      && GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[0] == 'acnet2.pyramidals_48[0].soma_0.v'
+      && GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[333] == 'acnet2.pyramidals_48[45].basal0_6.v'
+      && GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v')[456 - 1] == 'acnet2.baskets_12[11].dend_1.v';
+    },"getAllPotentialInstancesEndingWith .v returning expected paths");
+  });
 
-	casper.then(function () {
-		var instances = casper.evaluate(function() {return window.Instances.getInstance('acnet2.baskets_12[3]').getInstancePath();});
-		test.assertEquals(instances, 'acnet2.baskets_12[3]', "Instances.getInstance creates and fetches instance as expected. Tested with acnet2.baskets_12[3]");
-	});
+  casper.then(function () {
+    var instances = casper.evaluate(function () {
+      return window.Instances.getInstance('acnet2.baskets_12[3]').getInstancePath();
+    });
+    test.assertEquals(instances, 'acnet2.baskets_12[3]', "Instances.getInstance creates and fetches instance as expected. Tested with acnet2.baskets_12[3]");
+  });
 
-	casper.then(function () {
-		var instances = casper.evaluate(function() {return window.Instances.getInstance('acnet2.baskets_12[3].soma_0.v').getInstancePath();});
-		test.assertEquals(instances, 'acnet2.baskets_12[3].soma_0.v', 
-		"Instances.getInstance creates and fetches instance as expected. Tested with acnet2.baskets_12[3].soma_0.v");
-	});
+  casper.then(function () {
+    var instances = casper.evaluate(function () {
+      return window.Instances.getInstance('acnet2.baskets_12[3].soma_0.v').getInstancePath();
+    });
+    test.assertEquals(instances, 'acnet2.baskets_12[3].soma_0.v', 
+      "Instances.getInstance creates and fetches instance as expected. Tested with acnet2.baskets_12[3].soma_0.v");
+  });
 
-	casper.then(function () {
-		var instances = casper.evaluate(function() {window.Instances.getInstance('acnet2.baskets_12[3].sticaxxi')==undefined;});
-		test.assertEquals(instances, null, "Trying to fetch something that does not exist in the model throws exception");
-	});
+  casper.then(function () {
+    var instances = casper.evaluate(function () {
+      window.Instances.getInstance('acnet2.baskets_12[3].sticaxxi') == undefined;
+    });
+    test.assertEquals(instances, null, "Trying to fetch something that does not exist in the model throws exception");
+  });
 
-	/*Start Testing Injected Capabilities*/
-	casper.echo("----Start Testing Injected Capabilities----");
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.acnet2.baskets_12[0].hasCapability(GEPPETTO.Resources.VISUAL_CAPABILITY);
-		},"Visual capability injected to instances of visual types. Tested with acnet2.baskets_12[0]");
-	});
+  /* Start Testing Injected Capabilities*/
+  casper.echo("----Start Testing Injected Capabilities----");
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.acnet2.baskets_12[0].hasCapability(GEPPETTO.Resources.VISUAL_CAPABILITY);
+    },"Visual capability injected to instances of visual types. Tested with acnet2.baskets_12[0]");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.acnet2.baskets_12[0].getType().hasCapability(GEPPETTO.Resources.VISUAL_CAPABILITY);
-		},"Visual capability injected to types with visual types. Tested with acnet2.baskets_12[0]");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.acnet2.baskets_12[0].getType().hasCapability(GEPPETTO.Resources.VISUAL_CAPABILITY);
+    },"Visual capability injected to types with visual types. Tested with acnet2.baskets_12[0]");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.neuroml.network_ACnet2.temperature.hasCapability(GEPPETTO.Resources.PARAMETER_CAPABILITY);
-		},"Parameter capability injected to parameter instances. Tested with Model.neuroml.network_ACnet2.temperature");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.neuroml.network_ACnet2.temperature.hasCapability(GEPPETTO.Resources.PARAMETER_CAPABILITY);
+    },"Parameter capability injected to parameter instances. Tested with Model.neuroml.network_ACnet2.temperature");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.acnet2.pyramidals_48[0].hasCapability(GEPPETTO.Resources.VISUAL_GROUP_CAPABILITY);
-		}, "Visual group capability injected to instances of visual types with visual groups. Tested with acnet2.pyramidals_48[0]");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.acnet2.pyramidals_48[0].hasCapability(GEPPETTO.Resources.VISUAL_GROUP_CAPABILITY);
+    }, "Visual group capability injected to instances of visual types with visual groups. Tested with acnet2.pyramidals_48[0]");
+  });
 
-	casper.then(function () {
-		var getAllVariablesOfMetaType = casper.evaluate(function() {
-			var meta = GEPPETTO.ModelFactory.getAllTypesOfMetaType(GEPPETTO.Resources.COMPOSITE_TYPE_NODE);
-			var vars = GEPPETTO.ModelFactory.getAllVariablesOfMetaType(meta, 'ConnectionType')[0];
-			return vars.hasCapability(GEPPETTO.Resources.CONNECTION_CAPABILITY);
-		});
-		test.assertEquals(getAllVariablesOfMetaType, true, "Connection capability injected to variables of ConnectionType.");
-	});
+  casper.then(function () {
+    var getAllVariablesOfMetaType = casper.evaluate(function () {
+      var meta = GEPPETTO.ModelFactory.getAllTypesOfMetaType(GEPPETTO.Resources.COMPOSITE_TYPE_NODE);
+      var vars = GEPPETTO.ModelFactory.getAllVariablesOfMetaType(meta, 'ConnectionType')[0];
+      return vars.hasCapability(GEPPETTO.Resources.CONNECTION_CAPABILITY);
+    });
+    test.assertEquals(getAllVariablesOfMetaType, true, "Connection capability injected to variables of ConnectionType.");
+  });
 
-	casper.then(function () {
-		var getAllVariablesOfMetaType = casper.evaluate(function() {
-			return window.acnet2.pyramidals_48[0].getConnections()[0].hasCapability(GEPPETTO.Resources.CONNECTION_CAPABILITY);
-		});
-		test.assertEquals(getAllVariablesOfMetaType, true, "Connection capability injected to instances of connection types. Tested with acnet2.pyramidals_48[0]");
-	});
+  casper.then(function () {
+    var getAllVariablesOfMetaType = casper.evaluate(function () {
+      return window.acnet2.pyramidals_48[0].getConnections()[0].hasCapability(GEPPETTO.Resources.CONNECTION_CAPABILITY);
+    });
+    test.assertEquals(getAllVariablesOfMetaType, true, "Connection capability injected to instances of connection types. Tested with acnet2.pyramidals_48[0]");
+  });
 }

--- a/tests/casperjs/LiveTests.js
+++ b/tests/casperjs/LiveTests.js
@@ -1,23 +1,23 @@
-casper.test.begin('Geppetto basic tests', 5, function suite(test) {
-    casper.start("http://live.geppetto.org", function() {
-        this.waitForSelector('div[project-id="1"]', function() {
-            this.echo("I've waited for 10 seconds.");
-            test.assertTitle("geppetto's home", "geppetto's homepage title is the one expected");
-            test.assertExists('div[id="logo"]', "logo is found");
-            this.mouseEvent('dblclick','div[project-id="1"]');
-        }, null, 30000);
-    });
+casper.test.begin('Geppetto basic tests', 5, function suite (test) {
+  casper.start("http://live.geppetto.org", function () {
+    this.waitForSelector('div[project-id="1"]', function () {
+      this.echo("I've waited for 10 seconds.");
+      test.assertTitle("geppetto's home", "geppetto's homepage title is the one expected");
+      test.assertExists('div[id="logo"]', "logo is found");
+      this.mouseEvent('dblclick','div[project-id="1"]');
+    }, null, 30000);
+  });
 
-    casper.thenOpen("https://live.geppetto.org/geppetto?load_project_from_id=1",function() {
-        this.waitForSelector('div[id="Popup1"]', function() {
-            this.echo("I've waited for the popups to load.");
-            test.assertTitle("geppetto", "geppetto title is ok");
-            test.assertUrlMatch(/load_project_from_id=1/, "project load attempted");
-            test.assertExists('div[id="Popup1"]', "geppetto loads the description popup");
-        }, null, 30000);
-    });
+  casper.thenOpen("https://live.geppetto.org/geppetto?load_project_from_id=1",function () {
+    this.waitForSelector('div[id="Popup1"]', function () {
+      this.echo("I've waited for the popups to load.");
+      test.assertTitle("geppetto", "geppetto title is ok");
+      test.assertUrlMatch(/load_project_from_id=1/, "project load attempted");
+      test.assertExists('div[id="Popup1"]', "geppetto loads the description popup");
+    }, null, 30000);
+  });
 
-    casper.run(function() {
-        test.done();
-    });
+  casper.run(function () {
+    test.done();
+  });
 });

--- a/tests/casperjs/NeuronalProjectsTests.js
+++ b/tests/casperjs/NeuronalProjectsTests.js
@@ -1,75 +1,89 @@
-casper.test.begin('Geppetto neuronal projects tests', function suite(test) {
-	casper.options.viewportSize = {
-			width: 1340,
-			height: 768
-	};
+casper.test.begin('Geppetto neuronal projects tests', function suite (test) {
+  casper.options.viewportSize = {
+    width: 1340,
+    height: 768
+  };
 
-	casper.on("page.error", function(msg, trace) {
-		this.echo("Error: " + msg, "ERROR");
-	});
+  casper.on("page.error", function (msg, trace) {
+    this.echo("Error: " + msg, "ERROR");
+  });
 
-	// show page level errors
-	casper.on('resource.received', function (resource) {
-		var status = resource.status;
-		if (status >= 400) {
-			this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
-		}
-	});
+  // show page level errors
+  casper.on('resource.received', function (resource) {
+    var status = resource.status;
+    if (status >= 400) {
+      this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
+    }
+  });
 
-	casper.start(urlBase+"org.geppetto.frontend", function () {
-		this.echo(urlBase+baseFollowUp+hhcellProject);
-		this.waitForSelector('div[project-id="1"]', function () {
-			this.echo("I've waited for the projects to load.");
-			test.assertExists('div#logo', "logo is found");
-			test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
-			test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
-			test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
-			test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
-			test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
-			test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
-			test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
-			test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
-			test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
-			test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
-		}, null, 3000);
-	});
+  casper.start(urlBase + "org.geppetto.frontend", function () {
+    this.echo(urlBase + baseFollowUp + hhcellProject);
+    this.waitForSelector('div[project-id="1"]', function () {
+      this.echo("I've waited for the projects to load.");
+      test.assertExists('div#logo', "logo is found");
+      test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
+      test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
+      test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
+      test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
+      test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
+      test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
+      test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
+      test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
+      test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
+      test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
+    }, null, 3000);
+  });
 
-	/**Tests SingleComponentHH project**/
-	casper.thenOpen(urlBase+baseFollowUp+hhcellProject,function() {
-		casper.then(function(){testSingleCompononetHHProject(test);});
-	});
+  /** Tests SingleComponentHH project**/
+  casper.thenOpen(urlBase + baseFollowUp + hhcellProject,function () {
+    casper.then(function (){
+      testSingleCompononetHHProject(test);
+    });
+  });
 
-	/**Tests Primary Auditory Cortex Network project**/
-	casper.thenOpen(urlBase+baseFollowUp+acnetProject,function() {
-		casper.then(function(){testACNET2Project(test);});
-	});
+  /** Tests Primary Auditory Cortex Network project**/
+  casper.thenOpen(urlBase + baseFollowUp + acnetProject,function () {
+    casper.then(function (){
+      testACNET2Project(test);
+    });
+  });
 
-	/**Tests C302 Network project**/
-	casper.thenOpen(urlBase+baseFollowUp+c302Project,function() {
-		casper.then(function(){testC302NetworkProject(test);});
-	});
+  /** Tests C302 Network project**/
+  casper.thenOpen(urlBase + baseFollowUp + c302Project,function () {
+    casper.then(function (){
+      testC302NetworkProject(test);
+    });
+  });
 
-	/**Tests CA1 project**/
-	casper.thenOpen(urlBase+baseFollowUp+ca1Project,function() {
-		casper.then(function(){ca1Test(test);});
-	});
+  /** Tests CA1 project**/
+  casper.thenOpen(urlBase + baseFollowUp + ca1Project,function () {
+    casper.then(function (){
+      ca1Test(test);
+    });
+  });
 
-	/**Tests C.elegans PVDR Neuron morphology project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansPVDR,function() {
-		casper.then(function(){testPVDRNeuronProject(test);});
-	});
+  /** Tests C.elegans PVDR Neuron morphology project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansPVDR,function () {
+    casper.then(function (){
+      testPVDRNeuronProject(test);
+    });
+  });
 
-	/**Tests PMuscle cell NEURON project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansMuscleModel,function() {
-		casper.then(function(){testPMuscleCellProject(test);});
-	});
+  /** Tests PMuscle cell NEURON project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansMuscleModel,function () {
+    casper.then(function (){
+      testPMuscleCellProject(test);
+    });
+  });
 
-	/**Tests cElegansConnectome project**/
-	casper.thenOpen(urlBase+baseFollowUp+cElegansConnectome,function() {
-		casper.then(function(){testC302Connectome(test);});
-	});
+  /** Tests cElegansConnectome project**/
+  casper.thenOpen(urlBase + baseFollowUp + cElegansConnectome,function () {
+    casper.then(function (){
+      testC302Connectome(test);
+    });
+  });
 
-	casper.run(function() {
-		test.done();
-	});
+  casper.run(function () {
+    test.done();
+  });
 });

--- a/tests/casperjs/NeuronalTestsLogic.js
+++ b/tests/casperjs/NeuronalTestsLogic.js
@@ -2,824 +2,893 @@
  * Main method for testing the HHCEll project
  * @returns
  */
-function testSingleCompononetHHProject(test,name){
-    casper.then(function(){launchTest(test,"Single Component HH Project",45000);});
-    casper.echo("------------STARTING HHCELL TEST--------------");
-    casper.then(function(){
-    	casper.waitUntilVisible('div[id="Plot2"]', function () {
-    		casper.echo("-------Testing Widgets--------");
-    		casper.wait(2000, function(){
-        		//test plot widgets have expected amount of graphs by counting G elements plotly draws
-        		testPlotWidgets(test,"Plot1","hhcell.hhpop[0].v", 1);
-        		testPlotWidgets(test,"Plot2","hhcell.hhpop[0].bioPhys1.membraneProperties.naChans.na.m.q",3);
-           	});
-    	});
+function testSingleCompononetHHProject (test,name){
+  casper.then(function (){
+    launchTest(test,"Single Component HH Project",45000);
+  });
+  casper.echo("------------STARTING HHCELL TEST--------------");
+  casper.then(function (){
+    casper.waitUntilVisible('div[id="Plot2"]', function () {
+      casper.echo("-------Testing Widgets--------");
+      casper.wait(2000, function (){
+        // test plot widgets have expected amount of graphs by counting G elements plotly draws
+        testPlotWidgets(test,"Plot1","hhcell.hhpop[0].v", 1);
+        testPlotWidgets(test,"Plot2","hhcell.hhpop[0].bioPhys1.membraneProperties.naChans.na.m.q",3);
+      });
     });
-    casper.then(function () {
-		var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-		test.assertEquals(experiments, 1, "Initial amount of experiments for hhcell checked");
-	});
+  });
+  casper.then(function () {
+    var experiments = casper.evaluate(function () {
+      return window.Project.getExperiments().length;
+    });
+    test.assertEquals(experiments, 1, "Initial amount of experiments for hhcell checked");
+  });
     
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return hhcell!=null;});
-		test.assertEquals(evaluate,true, "Top level instance present");
-	});
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return hhcell != null;
+    });
+    test.assertEquals(evaluate,true, "Top level instance present");
+  });
     
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-			window.Model.getVariables()[0].getId() == 'hhcell' && window.Model.getVariables()[1].getId() == 'time';
-		},"2 top Variables as expected for hhcell");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 && window.Model.getVariables()[0].getId() == 'hhcell' && window.Model.getVariables()[1].getId() == 'time';
+    },"2 top Variables as expected for hhcell");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-		},"2 Libraries as expected for hhcell");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+    },"2 Libraries as expected for hhcell");
+  });
 
-	casper.then(function () {
-		test.assertEval(function() {
-			return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'hhcell';
-		},"1 top level instance as expected for hhcell");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'hhcell';
+    },"1 top level instance as expected for hhcell");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return hhcell.hhpop[0].bioPhys1.membraneProperties.naChans.na.h.q.getTimeSeries().length==6001;
-		},"Checking that time series length is 6001 in variable for hhcell project");
-    });
+  casper.then(function () {
+    test.assertEval(function () {
+      return hhcell.hhpop[0].bioPhys1.membraneProperties.naChans.na.h.q.getTimeSeries().length == 6001;
+    },"Checking that time series length is 6001 in variable for hhcell project");
+  });
     
-    casper.then(function(){
-    	casper.evaluate(function() {
-            Plot1.plotData(hhcell.hhpop[0].v);
-        });
+  casper.then(function (){
+    casper.evaluate(function () {
+      Plot1.plotData(hhcell.hhpop[0].v);
     });
-    casper.then(function(){
-    	testPlotWidgets(test,"Plot1","hhcell.hhpop[0].v", 1);
+  });
+  casper.then(function (){
+    testPlotWidgets(test,"Plot1","hhcell.hhpop[0].v", 1);
+  });
+  casper.then(function (){
+    removeAllPlots();
+  });
+  casper.then(function (){
+    casper.echo("-------Testing Camera Controls--------");
+    testCameraControls(test, [0,0,30.90193733102435]);
+  });
+  casper.then(function () {
+    casper.echo("Opening controls panel");
+    buttonClick("#controlPanelBtn");
+  });
+  casper.then(function (){
+    casper.echo("-------Testing Control Panel--------");
+    testInitialControlPanelValues(test,3);
+  });
+  casper.then(function (){
+    casper.echo("-------Testing Mesh Visibility--------");
+    testVisibility(test,"hhcell.hhpop[0]","#hhcell_hhpop_0__visibility_ctrlPanel_btn");
+  });
+  casper.then(function () {
+    casper.echo("-------Testing Plotting from Control Panel--------");
+    buttonClick("#stateVariablesFilterBtn");
+  });
+  casper.then(function () {
+    this.waitUntilVisible('button[id="hhcell_hhpop_0__v_plot_ctrlPanel_btn"]', function () {
+      buttonClick("#hhcell_hhpop_0__v_plot_ctrlPanel_btn");
     });
-    casper.then(function(){
-        removeAllPlots();
+  });
+  casper.then(function (){
+    this.waitUntilVisible('div[id="Plot1"]', function () {
+      this.echo("I've waited for Plot1 to come up");
     });
-    casper.then(function(){
-        casper.echo("-------Testing Camera Controls--------");
-        testCameraControls(test, [0,0,30.90193733102435]);
-    });
-    casper.then(function () {
-        casper.echo("Opening controls panel");
-        buttonClick("#controlPanelBtn");
-    });
-    casper.then(function(){
-        casper.echo("-------Testing Control Panel--------");
-        testInitialControlPanelValues(test,3);
-    });
-    casper.then(function(){
-        casper.echo("-------Testing Mesh Visibility--------");
-        testVisibility(test,"hhcell.hhpop[0]","#hhcell_hhpop_0__visibility_ctrlPanel_btn");
-    });
-    casper.then(function () {
-        casper.echo("-------Testing Plotting from Control Panel--------");
-        buttonClick("#stateVariablesFilterBtn");
-    });
-    casper.then(function () {
-        this.waitUntilVisible('button[id="hhcell_hhpop_0__v_plot_ctrlPanel_btn"]', function () {
-            buttonClick("#hhcell_hhpop_0__v_plot_ctrlPanel_btn");
-        });	
-    });
-    casper.then(function(){
-        this.waitUntilVisible('div[id="Plot1"]', function () {
-            this.echo("I've waited for Plot1 to come up");
-        });
-    });	
+  });
 
-    casper.then(function(){
-        buttonClick("#anyProjectFilterBtn");
-        removeAllPlots();
+  casper.then(function (){
+    buttonClick("#anyProjectFilterBtn");
+    removeAllPlots();
+  });
+
+  casper.then(function (){
+    removeAllPlots();
+    var rows = casper.evaluate(function () {
+      var rows = $(".standard-row").length;
+      return rows;
     });
-
-    casper.then(function(){
-        removeAllPlots();
-        var rows = casper.evaluate(function() {
-            var rows = $(".standard-row").length;
-            return rows;
-        });
-        test.assertEquals(rows, 10, "Correct amount of rows for Global filter");
-        casper.evaluate(function() {
-            $("#controlpanel").hide();
-        });
+    test.assertEquals(rows, 10, "Correct amount of rows for Global filter");
+    casper.evaluate(function () {
+      $("#controlpanel").hide();
     });
+  });
 
-    casper.then(function(){
-        casper.echo("-------Testing Spotlight--------");
-        testSpotlight(test, "hhcell.hhpop[0].v",'div[id="Plot1"]',true,false,"hhcell","hhcell.hhpop[0]");
+  casper.then(function (){
+    casper.echo("-------Testing Spotlight--------");
+    testSpotlight(test, "hhcell.hhpop[0].v",'div[id="Plot1"]',true,false,"hhcell","hhcell.hhpop[0]");
+  });
+
+  casper.then(function () {
+    closeSpotlight();
+    // adding few widgets to the project to test View state later
+    casper.evaluate(function (){
+      GEPPETTO.ComponentFactory.addWidget('CANVAS', { name: '3D Canvas', }, function () {
+        this.setName('Widget Canvas');this.setPosition();this.display([hhcell])
+      });
+      Plot1.setPosition(0,300);
+      G.addWidget(1).then(w => {
+        w.setMessage("Hhcell popup");
+      });
+      G.addWidget(1).then(w => {
+        w.setMessage("Hhcell popup 2").addCustomNodeHandler(function (){},'click');
+      });
     });
+  });
 
-    casper.then(function () {
-        closeSpotlight();
-        //adding few widgets to the project to test View state later
-        casper.evaluate(function(){
-            GEPPETTO.ComponentFactory.addWidget('CANVAS', {name: '3D Canvas',}, function () {this.setName('Widget Canvas');this.setPosition();this.display([hhcell])});
-            Plot1.setPosition(0,300);
-            G.addWidget(1).then(w=>{w.setMessage("Hhcell popup");});
-            G.addWidget(1).then(w=>{w.setMessage("Hhcell popup 2").addCustomNodeHandler(function(){},'click');});
-        });
+  casper.then(function () {
+    // toggle tutorial if tutorial button exists
+    if (casper.exists('#tutorialBtn')){
+      casper.mouseEvent('click', 'button#tutorialBtn', "attempting to open tutorial");
+      // click on next step for Tutorial
+      casper.evaluate(function () {
+        var nextBtnSelector = $(".nextBtn");
+        nextBtnSelector.click();
+        nextBtnSelector.click();
+      });
+    }
+  });
+
+  casper.then(function () {
+    // tests widget canvas has mesh
+    var mesh = casper.evaluate(function (){
+      var mesh = Canvas2.engine.getRealMeshesForInstancePath("hhcell.hhpop[0]").length;
+      return mesh;
     });
+    test.assertEquals(mesh, 1, "Canvas widget has hhcell");
+  });
 
-    casper.then(function () {
-        //toggle tutorial if tutorial button exists
-        if(casper.exists('#tutorialBtn')){
-            casper.mouseEvent('click', 'button#tutorialBtn', "attempting to open tutorial");
-            //click on next step for Tutorial
-            casper.evaluate(function () {
-                var nextBtnSelector = $(".nextBtn");
-                nextBtnSelector.click();
-                nextBtnSelector.click();
-            });
-        }
+  casper.then(function (){
+    casper.echo("-------Testing Camera Controls on main Canvas and Canvas widget--------");
+    testCameraControlsWithCanvasWidget(test, [0,0,30.90193733102435]);
+  });
+
+  // test color Function
+  casper.then(function (){
+    var initialColorFunctions = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
     });
-
-    casper.then(function () {
-        //tests widget canvas has mesh
-        var mesh = casper.evaluate(function(){
-            var mesh = Canvas2.engine.getRealMeshesForInstancePath("hhcell.hhpop[0]").length;
-            return mesh;
-        });
-        test.assertEquals(mesh, 1, "Canvas widget has hhcell");
+    casper.echo("-------Testing Color Function--------");
+    // add color Function
+    casper.evaluate(function (){
+      GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
+      Project.getActiveExperiment().play({ step:10 });
     });
-
-    casper.then(function(){	
-        casper.echo("-------Testing Camera Controls on main Canvas and Canvas widget--------");
-        testCameraControlsWithCanvasWidget(test, [0,0,30.90193733102435]);
+    var colorFunctionInstances = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
     });
+    test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
+    // test3DMeshColorNotEquals(test,defaultColor,"hhcell.hhpop[0]");
+    casper.echo("Done Playing, now exiting");
+  });
 
-    //test color Function
-    casper.then(function(){
-        var initialColorFunctions = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        casper.echo("-------Testing Color Function--------");
-        //add color Function
-        casper.evaluate(function(){
-            GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
-            Project.getActiveExperiment().play({step:10});
-        });
-        var colorFunctionInstances = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
-        //test3DMeshColorNotEquals(test,defaultColor,"hhcell.hhpop[0]");
-        casper.echo("Done Playing, now exiting");
+  // reload test, needed for testing view comes up
+  casper.then(function (){
+    launchTest(test,"Hhcell",30000);
+  });
+
+  // testing widgets stored in View state come up
+  casper.then(function (){
+    test.assertVisible('div#Canvas2', "Canvas2 is correctly open on reload.");
+    test.assertVisible('div#Plot1', "Plot1 is correctly open on reload");
+    test.assertVisible('div#Popup1', "Popup1 is correctly open on reload");
+    test.assertVisible('div#Popup2', "Popup2 is correctly open on reload");
+
+    // if tutorial button exists, tests existence of Tutorial
+    if (casper.exists('#tutorialBtn')){
+      test.assertVisible('div#Tutorial1', "Tutorial1 is correctly open on reload");
+      var tutorialStep = casper.evaluate(function () {
+        return Tutorial1.state.currentStep;
+      });
+      test.assertEquals(tutorialStep, 2, "Tutorial1 step restored correctly");
+    }
+    // Tests content of Popup1 
+    var popUpMessage = casper.evaluate(function () {
+      return $("#Popup1").html();
     });
+    test.assertEquals(popUpMessage, "Hhcell popup", "Popup1 message restored correctly");
 
-    //reload test, needed for testing view comes up
-    casper.then(function(){launchTest(test,"Hhcell",30000);});
+    // Tests popup has custom handlers
+    var popUpCustomHandler = casper.evaluate(function () {
+      return Popup2.customHandlers;
+    });
+    test.assertEquals(popUpCustomHandler.length, 1, "Popup2 custom handlers restored correctly");
+    test.assertEquals(popUpCustomHandler[0]["event"], "click", "Popup2 custom handlers event restored correctly");
 
-    //testing widgets stored in View state come up
-    casper.then(function(){
-        test.assertVisible('div#Canvas2', "Canvas2 is correctly open on reload.");
-        test.assertVisible('div#Plot1', "Plot1 is correctly open on reload");
-        test.assertVisible('div#Popup1', "Popup1 is correctly open on reload");
-        test.assertVisible('div#Popup2', "Popup2 is correctly open on reload");
-
-        //if tutorial button exists, tests existence of Tutorial
-        if(casper.exists('#tutorialBtn')){
-            test.assertVisible('div#Tutorial1', "Tutorial1 is correctly open on reload");
-            var tutorialStep = casper.evaluate(function() {
-                return Tutorial1.state.currentStep;
-            });
-            test.assertEquals(tutorialStep, 2, "Tutorial1 step restored correctly");
-        }
-        //Tests content of Popup1 
-        var popUpMessage = casper.evaluate(function() {
-            return $("#Popup1").html();
-        });
-        test.assertEquals(popUpMessage, "Hhcell popup", "Popup1 message restored correctly");
-
-        //Tests popup has custom handlers
-        var popUpCustomHandler = casper.evaluate(function() {
-            return Popup2.customHandlers;
-        });
-        test.assertEquals(popUpCustomHandler.length, 1, "Popup2 custom handlers restored correctly");
-        test.assertEquals(popUpCustomHandler[0]["event"], "click", "Popup2 custom handlers event restored correctly");
-
-        //Test canvas widget has mesh 
-        var meshInCanvas2Exists = casper.evaluate(function() {
-            var mesh = Canvas1.engine.meshes["hhcell.hhpop[0]"];
-            if(mesh!=null && mesh!=undefined){
-                return true;
-            }
-            return false;
-        });
-        test.assertEquals(meshInCanvas2Exists, true, "Canvas2 hhcell set correctly");
-    });	
+    // Test canvas widget has mesh 
+    var meshInCanvas2Exists = casper.evaluate(function () {
+      var mesh = Canvas1.engine.meshes["hhcell.hhpop[0]"];
+      if (mesh != null && mesh != undefined){
+        return true;
+      }
+      return false;
+    });
+    test.assertEquals(meshInCanvas2Exists, true, "Canvas2 hhcell set correctly");
+  });	
 }
 
 /**
  * Main method for testing ACNet
  */
-function testACNET2Project(test){
-    casper.then(function(){launchTest(test,"ACNET2",45000);});
-    casper.echo("------------Starting Primary Auditory Cortary Test--------------");
-    casper.then(function () {
-		var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-		test.assertEquals(experiments, 2, "Initial amount of experiments for ACNE2 checked");
-	});
+function testACNET2Project (test){
+  casper.then(function (){
+    launchTest(test,"ACNET2",45000);
+  });
+  casper.echo("------------Starting Primary Auditory Cortary Test--------------");
+  casper.then(function () {
+    var experiments = casper.evaluate(function () {
+      return window.Project.getExperiments().length;
+    });
+    test.assertEquals(experiments, 2, "Initial amount of experiments for ACNE2 checked");
+  });
     
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return acnet2!=null;});
-		test.assertEquals(evaluate,true, "Top level instance present");
-	});
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return acnet2 != null;
+    });
+    test.assertEquals(evaluate,true, "Top level instance present");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return acnet2.baskets_12[3] != undefined && acnet2.pyramidals_48[12] != undefined;
-		},"Instances exploded as expected");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.baskets_12[3] != undefined && acnet2.pyramidals_48[12] != undefined;
+    },"Instances exploded as expected");
+  });
     
-    casper.page.onCallback = function(){
-    	test.assertEval(function() {
-			return acnet2.baskets_12[9].getConnections().length===60 && acnet2.pyramidals_48[23].getConnections().length===22;
-		},"bask and pyramidal connections check after resolveAllImportTypes() call.");
-    };
+  casper.page.onCallback = function (){
+    test.assertEval(function () {
+      return acnet2.baskets_12[9].getConnections().length === 60 && acnet2.pyramidals_48[23].getConnections().length === 22;
+    },"bask and pyramidal connections check after resolveAllImportTypes() call.");
+  };
     
-    casper.then(function () {
-		casper.evaluate(function() {Model.neuroml.resolveAllImportTypes(window.callPhantom);});
-	});
+  casper.then(function () {
+    casper.evaluate(function () {
+      Model.neuroml.resolveAllImportTypes(window.callPhantom);
+    });
+  });
     
-    casper.then(function () {
-    	test.assertEval(function() {
-    		return acnet2.pyramidals_48[23].getVisualGroups().length==5;
-    	},"Test number of Visual Groups on pyramidals");
-    });
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.pyramidals_48[23].getVisualGroups().length == 5;
+    },"Test number of Visual Groups on pyramidals");
+  });
 
-    casper.then(function () {
-    	test.assertEval(function() {
-    		return acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups().length==3;
-    	},"Test number of Visual Groups on acnet2.baskets_12[0]");
-    });
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.baskets_12[0].getTypes()[0].getVisualType().getVisualGroups().length == 3;
+    },"Test number of Visual Groups on acnet2.baskets_12[0]");
+  });
     
-    casper.then(function () {
-    	test.assertEval(function() {
-    		return acnet2.pyramidals_48[23].getVisualGroups().length==5;
-    	},"Test number of Visual Groups on pyramidals");
-    });
+  casper.then(function () {
+    test.assertEval(function () {
+      return acnet2.pyramidals_48[23].getVisualGroups().length == 5;
+    },"Test number of Visual Groups on pyramidals");
+  });
 
-    casper.then(function () {
-    	test.assertEval(function() {
-			return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-            window.Model.getVariables()[0].getId() == 'acnet2' && window.Model.getVariables()[1].getId() == 'time';
-		},"2 top Variables as expected for ACNET2");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2
+            && window.Model.getVariables()[0].getId() == 'acnet2' && window.Model.getVariables()[1].getId() == 'time';
+    },"2 top Variables as expected for ACNET2");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-		},"2 Libraries as expected for ACNET2");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+    },"2 Libraries as expected for ACNET2");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'acnet2';
-		},"1 top level instance as expected for ACNET2");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'acnet2';
+    },"1 top level instance as expected for ACNET2");
+  });
     
-    casper.then(function(){
-        removeAllPlots();
+  casper.then(function (){
+    removeAllPlots();
+  });
+  casper.then(function (){
+    casper.echo("-------Testing Camera Controls--------");
+    testCameraControls(test,[231.95608349343888,508.36555704435455,1849.839]);
+  });
+  casper.then(function () {
+    casper.echo("-------Testing Original Color--------");
+    test3DMeshColor(test,[0.796078431372549,0,0],"acnet2.pyramidals_48[0]");
+    test3DMeshColor(test,[0.796078431372549,0,0],"acnet2.pyramidals_48[47]");
+    test3DMeshColor(test,[0,0.2,0.596078431372549],"acnet2.baskets_12[0]");
+    test3DMeshColor(test,[0,0.2,0.596078431372549],"acnet2.baskets_12[11]");
+    this.echo("Opening controls panel");
+    buttonClick("#controlPanelBtn");
+  });
+
+  casper.then(function () {
+    casper.echo("-------Testing Control Panel--------");
+    testInitialControlPanelValues(test,10);
+  });
+  casper.then(function (){
+    casper.echo("-------Testing Mesh Visibility--------");
+    testVisibility(test,"acnet2.pyramidals_48[0]","#acnet2_pyramidals_48_0__visibility_ctrlPanel_btn");
+  });
+  casper.then(function () {
+    casper.echo("-------Testing Plotting from Control Panel--------");
+    buttonClick("#stateVariablesFilterBtn");
+  });
+
+  casper.then(function () {
+    this.waitUntilVisible('button[id="acnet2_pyramidals_48_0__soma_0_v_plot_ctrlPanel_btn"]', function () {
+      buttonClick("#acnet2_pyramidals_48_0__soma_0_v_plot_ctrlPanel_btn");
     });
-    casper.then(function(){
-        casper.echo("-------Testing Camera Controls--------");
-        testCameraControls(test,[231.95608349343888,508.36555704435455,1849.839]);
+  });
+
+  casper.then(function () {
+    this.waitUntilVisible('div[id="Plot1"]', function () {
+      test.assertExists('div[id="Plot1"]', "Plot1 exists");
+      casper.evaluate(function () {
+        $("#controlpanel").hide();
+      });
     });
-    casper.then(function () {
-        casper.echo("-------Testing Original Color--------");
-        test3DMeshColor(test,[0.796078431372549,0,0],"acnet2.pyramidals_48[0]");
-        test3DMeshColor(test,[0.796078431372549,0,0],"acnet2.pyramidals_48[47]");
-        test3DMeshColor(test,[0,0.2,0.596078431372549],"acnet2.baskets_12[0]");
-        test3DMeshColor(test,[0,0.2,0.596078431372549],"acnet2.baskets_12[11]");
-        this.echo("Opening controls panel");
-        buttonClick("#controlPanelBtn");
-    });
+  });
 
-    casper.then(function () {
-        casper.echo("-------Testing Control Panel--------");
-        testInitialControlPanelValues(test,10);
-    });
-    casper.then(function(){
-        casper.echo("-------Testing Mesh Visibility--------");
-        testVisibility(test,"acnet2.pyramidals_48[0]","#acnet2_pyramidals_48_0__visibility_ctrlPanel_btn");
-    });
-    casper.then(function () {
-        casper.echo("-------Testing Plotting from Control Panel--------");
-        buttonClick("#stateVariablesFilterBtn");
-    });
+  casper.then(function (){
+    removeAllPlots(); // removes exisiting plots for clearer view
+  });
 
-    casper.then(function () {
-        this.waitUntilVisible('button[id="acnet2_pyramidals_48_0__soma_0_v_plot_ctrlPanel_btn"]', function () {
-            buttonClick("#acnet2_pyramidals_48_0__soma_0_v_plot_ctrlPanel_btn");
-        });	
-    });
+  casper.then(function () {
+    casper.echo("-------Testing Spotlight--------");
+    testSpotlight(test, "acnet2.pyramidals_48[1].soma_0.v",'div[id="Plot1"]',true,true,"acnet2.pyramidals_48[0]","acnet2.pyramidals_48[0]");
+    this.mouseEvent('click', 'i.fa-search', "attempting to close spotlight");
+  });
 
-    casper.then(function () {
-        this.waitUntilVisible('div[id="Plot1"]', function () {
-            test.assertExists('div[id="Plot1"]', "Plot1 exists");
-            casper.evaluate(function() {
-                $("#controlpanel").hide();
-            });			
-        });
-    });
+  casper.then(function () {
+    casper.echo("-------Testing Connected cells to Instance--------");
 
-    casper.then(function(){
-        removeAllPlots(); //removes exisiting plots for clearer view
-    });
+    // testing right amount of connection lines are shown
+    testingConnectionLines(test,23);
 
-    casper.then(function () {
-        casper.echo("-------Testing Spotlight--------");
-        testSpotlight(test, "acnet2.pyramidals_48[1].soma_0.v",'div[id="Plot1"]',true,true,"acnet2.pyramidals_48[0]","acnet2.pyramidals_48[0]");	
-        this.mouseEvent('click', 'i.fa-search', "attempting to close spotlight");
-    });
+    // testing that connected cells of acnet2.pyramidals_48[0] have changed color
+    test3DMeshColorNotEquals(test,defaultColor, "acnet2.baskets_12[4]");
+    test3DMeshColor(test,[0.39215686274509803,0.5882352941176471,0.08235294117647059], "acnet2.baskets_12[4]");
 
-    casper.then(function () {
-        casper.echo("-------Testing Connected cells to Instance--------");
+    test3DMeshColorNotEquals(test,defaultColor, "acnet2.baskets_12[1]");
+    test3DMeshColor(test,[1,0.35294117647058826,0.00784313725490196], "acnet2.baskets_12[1]");
 
-        //testing right amount of connection lines are shown
-        testingConnectionLines(test,23);
+    // test they are ghosted
+    test3DMeshOpacity(test,0.3, "acnet2.baskets_12[4]");
+    test3DMeshOpacity(test,0.3, "acnet2.baskets_12[1]");
 
-        //testing that connected cells of acnet2.pyramidals_48[0] have changed color
-        test3DMeshColorNotEquals(test,defaultColor, "acnet2.baskets_12[4]");
-        test3DMeshColor(test,[0.39215686274509803,0.5882352941176471,0.08235294117647059], "acnet2.baskets_12[4]");
+  });
 
-        test3DMeshColorNotEquals(test,defaultColor, "acnet2.baskets_12[1]");
-        test3DMeshColor(test,[1,0.35294117647058826,0.00784313725490196], "acnet2.baskets_12[1]");
+  casper.then(function () {
+    testSpotlight(test, "acnet2.pyramidals_48[0].biophys.membraneProperties.Ca_pyr_soma_group.gDensity",'div[id="Plot1"]',false,false,"acnet2.pyramidals_48[0]");
+  });
 
-        //test they are ghosted
-        test3DMeshOpacity(test,0.3, "acnet2.baskets_12[4]");
-        test3DMeshOpacity(test,0.3, "acnet2.baskets_12[1]");
-
-    });
-
-    casper.then(function () {
-        testSpotlight(test, "acnet2.pyramidals_48[0].biophys.membraneProperties.Ca_pyr_soma_group.gDensity",'div[id="Plot1"]',false,false,"acnet2.pyramidals_48[0]");	
-    });
-
-    casper.then(function () {
-        casper.evaluate(function(){
-            acnet2.pyramidals_48[0].deselect();
-        });
-
-        //test these cells are no longer ghosted
-        test3DMeshOpacity(test,1, "acnet2.baskets_12[1]");
-        test3DMeshOpacity(test,1, "acnet2.baskets_12[4]");
+  casper.then(function () {
+    casper.evaluate(function (){
+      acnet2.pyramidals_48[0].deselect();
     });
 
-    casper.then(function () {
-        closeSpotlight(); //close spotlight before continuing
-        casper.echo("-------Testing Canvas Widget and Camera Controls--------");
+    // test these cells are no longer ghosted
+    test3DMeshOpacity(test,1, "acnet2.baskets_12[1]");
+    test3DMeshOpacity(test,1, "acnet2.baskets_12[4]");
+  });
 
-        //adding few widgets to the project to test View state later
-        casper.evaluate(function(){
-            GEPPETTO.ComponentFactory.addWidget('CANVAS', {name: '3D Canvas',}, function () {this.setName('Widget Canvas');this.setPosition();this.display([acnet2])});
-            Plot1.setPosition(0,300); // get out of the way 
-            acnet2.baskets_12[4].getVisualGroups()[0].show(true);
-        });		
+  casper.then(function () {
+    closeSpotlight(); // close spotlight before continuing
+    casper.echo("-------Testing Canvas Widget and Camera Controls--------");
+
+    // adding few widgets to the project to test View state later
+    casper.evaluate(function (){
+      GEPPETTO.ComponentFactory.addWidget('CANVAS', { name: '3D Canvas', }, function () {
+        this.setName('Widget Canvas');this.setPosition();this.display([acnet2])
+      });
+      Plot1.setPosition(0,300); // get out of the way 
+      acnet2.baskets_12[4].getVisualGroups()[0].show(true);
+    });		
+  });
+
+  casper.then(function () {
+    // tests camera controls are working by checking camera has moved
+    testCameraControlsWithCanvasWidget(test,[231.95608349343888,508.36555704435455,1849.839]);
+  });
+
+  casper.then(function () {
+    // applies visual group to instance and tests colors
+    testVisualGroup(test,"acnet2.baskets_12[0]",2,[[],[0,0.4,1],[0.6,0.8,0]]);
+    testVisualGroup(test,"acnet2.baskets_12[5]",2,[[],[0,0.4,1],[0.6,0.8,0]]);
+  });
+
+  casper.then(function (){
+    casper.echo("Testing setGeometry");
+
+    casper.evaluate(function (){
+      acnet2.pyramidals_48[0].setGeometryType("cylinders")
     });
 
-    casper.then(function () {
-        //tests camera controls are working by checking camera has moved
-        testCameraControlsWithCanvasWidget(test,[231.95608349343888,508.36555704435455,1849.839]);
+    // test mesh set geometry
+    var meshType = casper.evaluate(function (){
+      return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
+    });
+    test.assertEquals(meshType, "Mesh", "Correctly set mesh to cylinders");
+
+    var meshTotal = casper.evaluate(function (){
+      return Object.keys(Canvas1.engine.meshes).length;
+    });
+    test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
+
+    // retrieve original color pre setGeomtry
+    var color = getMeshColor(test,"acnet2.pyramidals_48[0]");
+    casper.evaluate(function (){
+      acnet2.pyramidals_48[0].setGeometryType("lines")
     });
 
-    casper.then(function () {
-        //applies visual group to instance and tests colors
-        testVisualGroup(test,"acnet2.baskets_12[0]",2,[[],[0,0.4,1],[0.6,0.8,0]]);	
-        testVisualGroup(test,"acnet2.baskets_12[5]",2,[[],[0,0.4,1],[0.6,0.8,0]]);
+    casper.echo("Testing color post setGeometryType");
+    test3DMeshColor(test,color,"acnet2.pyramidals_48[0]");
+
+    // test mesh set geometry
+    meshType = casper.evaluate(function (){
+      return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
+    });
+    test.assertEquals(meshType, "LineSegments", "Correctly set mesh to lines");
+
+    // testsing same amount of meshes exists after changing a mesh to lines
+    var meshTotal = casper.evaluate(function (){
+      return Object.keys(Canvas1.engine.meshes).length;
+    });
+    test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
+
+    // Set geometry type to cylinders
+    casper.evaluate(function (){
+      acnet2.pyramidals_48[0].setGeometryType("cylinders")
     });
 
-    casper.then(function(){
-        casper.echo("Testing setGeometry");
-
-        casper.evaluate(function(){
-            acnet2.pyramidals_48[0].setGeometryType("cylinders")
-        });
-
-        //test mesh set geometry
-        var meshType = casper.evaluate(function(){
-            return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
-        });
-        test.assertEquals(meshType, "Mesh", "Correctly set mesh to cylinders");
-
-        var meshTotal = casper.evaluate(function(){
-            return Object.keys(Canvas1.engine.meshes).length;
-        });
-        test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
-
-        //retrieve original color pre setGeomtry
-        var color = getMeshColor(test,"acnet2.pyramidals_48[0]");
-        casper.evaluate(function(){
-            acnet2.pyramidals_48[0].setGeometryType("lines")
-        });
-
-        casper.echo("Testing color post setGeometryType");
-        test3DMeshColor(test,color,"acnet2.pyramidals_48[0]");
-
-        //test mesh set geometry
-        meshType = casper.evaluate(function(){
-            return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
-        });
-        test.assertEquals(meshType, "LineSegments", "Correctly set mesh to lines");
-
-        //testsing same amount of meshes exists after changing a mesh to lines
-        var meshTotal = casper.evaluate(function(){
-            return Object.keys(Canvas1.engine.meshes).length;
-        });
-        test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
-
-        //Set geometry type to cylinders
-        casper.evaluate(function(){
-            acnet2.pyramidals_48[0].setGeometryType("cylinders")
-        });
-
-        //test  set geometry type in a mesh
-        var meshType = casper.evaluate(function(){
-            return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
-        });
-        test.assertEquals(meshType, "Mesh", "Correctly set mesh to cylinders");
-
-        casper.echo("Testing color post setGeometryType to cylinders");
-        test3DMeshColor(test,color,"acnet2.pyramidals_48[0]");
-
-        //testing same amount of meshes exists after changing a mesh to cylinders
-        var meshTotal = casper.evaluate(function(){
-            return Object.keys(Canvas1.engine.meshes).length;
-        });
-        test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
+    // test  set geometry type in a mesh
+    var meshType = casper.evaluate(function (){
+      return Canvas1.engine.getRealMeshesForInstancePath("acnet2.pyramidals_48[0]")[0].type;
     });
+    test.assertEquals(meshType, "Mesh", "Correctly set mesh to cylinders");
 
-    casper.then(function () {
-        var initialColorFunctions = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        casper.echo("-------Testing Color Function--------");
-        //add color Function
-        casper.evaluate(function(){
-            GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
-            Project.getActiveExperiment().play({step:10});
-        });
-        var colorFunctionInstances = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
-        //		casper.wait(2000, function(){
-        //			//test color function
-        //			test3DMeshColorNotEquals(test,defaultColor,"acnet2.baskets_12[2].soma_0");
-        //		});
-        casper.echo("Done Playing, now exiting");
+    casper.echo("Testing color post setGeometryType to cylinders");
+    test3DMeshColor(test,color,"acnet2.pyramidals_48[0]");
+
+    // testing same amount of meshes exists after changing a mesh to cylinders
+    var meshTotal = casper.evaluate(function (){
+      return Object.keys(Canvas1.engine.meshes).length;
     });
+    test.assertEquals(meshTotal, 60, "Correctly amount of meshes after applying cylinders");
+  });
+
+  casper.then(function () {
+    var initialColorFunctions = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
+    });
+    casper.echo("-------Testing Color Function--------");
+    // add color Function
+    casper.evaluate(function (){
+      GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
+      Project.getActiveExperiment().play({ step:10 });
+    });
+    var colorFunctionInstances = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
+    });
+    test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
+    /*
+     * casper.wait(2000, function(){
+     * //test color function
+     * test3DMeshColorNotEquals(test,defaultColor,"acnet2.baskets_12[2].soma_0");
+     * });
+     */
+    casper.echo("Done Playing, now exiting");
+  });
 }
 
-function testC302NetworkProject(test){
-    casper.then(function(){launchTest(test,"C302",45000);});
-    casper.echo("------------STARTING C302 NETWORK TEST--------------");
+function testC302NetworkProject (test){
+  casper.then(function (){
+    launchTest(test,"C302",45000);
+  });
+  casper.echo("------------STARTING C302 NETWORK TEST--------------");
     
-    casper.then(function(){
-    	casper.waitUntilVisible('div[id="Plot1"]', function () {
-    		this.echo("I've waited for Plot1 to load.");
-    		test.assertExists('div[id="Plot1"]', "geppetto loads the initial Plot1");
+  casper.then(function (){
+    casper.waitUntilVisible('div[id="Plot1"]', function () {
+      this.echo("I've waited for Plot1 to load.");
+      test.assertExists('div[id="Plot1"]', "geppetto loads the initial Plot1");
 
-    		casper.then(function(){
-    			casper.waitUntilVisible('div[id="loading-spinner"]', function () {
-    				this.echo("I've waited for resolve types loading spinner to appear.");
-    			},125000);
-    		});
-    	},25000);
-    });
+      casper.then(function (){
+        casper.waitUntilVisible('div[id="loading-spinner"]', function () {
+          this.echo("I've waited for resolve types loading spinner to appear.");
+        },125000);
+      });
+    },25000);
+  });
     
-    casper.then(function () {
-		var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-		test.assertEquals(experiments, 2, "Initial amount of experiments for C302 checked");
-	});
+  casper.then(function () {
+    var experiments = casper.evaluate(function () {
+      return window.Project.getExperiments().length;
+    });
+    test.assertEquals(experiments, 2, "Initial amount of experiments for C302 checked");
+  });
     
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return c302.getChildren().length;});
-		test.assertEquals(evaluate, 299, "C302 Children count checked");
-	});
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return c302.getChildren().length;
+    });
+    test.assertEquals(evaluate, 299, "C302 Children count checked");
+  });
     
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return c302!=null;});
-		test.assertEquals(evaluate,true, "Top level instance present");
-	});
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return c302 != null;
+    });
+    test.assertEquals(evaluate,true, "Top level instance present");
+  });
     
-    casper.page.onCallback = function(){
-    	casper.echo("-------Testing Resolved Connections--------");
+  casper.page.onCallback = function (){
+    casper.echo("-------Testing Resolved Connections--------");
 
-    	test.assertEval(function() {
-    		return c302.ADAL[0].getConnections().length=== 31;
-    	},"ADAL connections check after resolveAllImportTypes() call.");
+    test.assertEval(function () {
+      return c302.ADAL[0].getConnections().length === 31;
+    },"ADAL connections check after resolveAllImportTypes() call.");
 
-    	test.assertEval(function() {
-    		return c302.AVAL[0].getConnections().length === 170;
-    	},"AVAL connections check after resolveAllImportTypes() call.");
+    test.assertEval(function () {
+      return c302.AVAL[0].getConnections().length === 170;
+    },"AVAL connections check after resolveAllImportTypes() call.");
 
-    	test.assertEval(function() {
-    		return c302.PVDR[0].getConnections().length===7;
-    	},"PVDRD connections check after resolveAllImportTypes() call.");
-    };
+    test.assertEval(function () {
+      return c302.PVDR[0].getConnections().length === 7;
+    },"PVDRD connections check after resolveAllImportTypes() call.");
+  };
 
-    casper.then(function () {
-    	casper.echo("-------Executing command Model.neuroml.resolveAllImportTypes()--------");
-    	casper.evaluate(function() {Model.neuroml.resolveAllImportTypes(window.callPhantom);});
+  casper.then(function () {
+    casper.echo("-------Executing command Model.neuroml.resolveAllImportTypes()--------");
+    casper.evaluate(function () {
+      Model.neuroml.resolveAllImportTypes(window.callPhantom);
     });
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-            window.Model.getVariables()[0].getId() == 'c302' && window.Model.getVariables()[1].getId() == 'time';
-		},"2 top Variables as expected for C302");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2
+            && window.Model.getVariables()[0].getId() == 'c302' && window.Model.getVariables()[1].getId() == 'time';
+    },"2 top Variables as expected for C302");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-		},"2 Libraries as expected for C302");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+    },"2 Libraries as expected for C302");
+  });
     
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'c302';
-		},"1 top level instance as expected for C302");
-	});
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'c302';
+    },"1 top level instance as expected for C302");
+  });
 
-    casper.then(function(){
-        resetCameraTest(test, [49.25,-0.8000001907348633,733.3303486467378]);
-    });
+  casper.then(function (){
+    resetCameraTest(test, [49.25,-0.8000001907348633,733.3303486467378]);
+  });
 
-    casper.then(function(){
-        removeAllPlots();
-    });
+  casper.then(function (){
+    removeAllPlots();
+  });
 
-    casper.then(function(){
-        casper.echo("-------Testing Camera Controls--------");
-        testCameraControls(test, [49.25,-0.8000001907348633,733.3303486467378]);
-    });
-    casper.then(function () {
-        test3DMeshColor(test,defaultColor,"c302.ADAL[0]");
-        casper.echo("Opening controls panel");
-        buttonClick("#controlPanelBtn");
-    });
+  casper.then(function (){
+    casper.echo("-------Testing Camera Controls--------");
+    testCameraControls(test, [49.25,-0.8000001907348633,733.3303486467378]);
+  });
+  casper.then(function () {
+    test3DMeshColor(test,defaultColor,"c302.ADAL[0]");
+    casper.echo("Opening controls panel");
+    buttonClick("#controlPanelBtn");
+  });
 
-    casper.then(function(){
-        testInitialControlPanelValues(test,10);
-    });
+  casper.then(function (){
+    testInitialControlPanelValues(test,10);
+  });
 
-    casper.then(function () {
-        buttonClick("#stateVariablesFilterBtn");
-    });
+  casper.then(function () {
+    buttonClick("#stateVariablesFilterBtn");
+  });
 
-    casper.then(function(){
-        this.waitUntilVisible('button[id="c302_ADAL_0__v_plot_ctrlPanel_btn"]', function () {
-            buttonClick("#c302_ADAL_0__v_plot_ctrlPanel_btn");
+  casper.then(function (){
+    this.waitUntilVisible('button[id="c302_ADAL_0__v_plot_ctrlPanel_btn"]', function () {
+      buttonClick("#c302_ADAL_0__v_plot_ctrlPanel_btn");
+    });
+  });
+
+  casper.then(function (){
+    this.waitUntilVisible('div[id="Plot1"]', function () {
+      this.echo("I've waited for Plot1 to come up");
+      buttonClick("#anyProjectFilterBtn");
+      this.wait(500,function (){
+        var rows = casper.evaluate(function () {
+          var rows = $(".standard-row").length;
+          return rows;
         });
-    });
-
-    casper.then(function(){
-        this.waitUntilVisible('div[id="Plot1"]', function () {
-            this.echo("I've waited for Plot1 to come up");
-            buttonClick("#anyProjectFilterBtn");
-            this.wait(500,function(){
-                var rows = casper.evaluate(function() {
-                    var rows = $(".standard-row").length;
-                    return rows;
-                });
-                test.assertEquals(rows, 10, "Correct amount of rows for Global filter");
-                casper.evaluate(function() {
-                    $("#controlpanel").hide();
-                });	
-                casper.echo("-------Testing Spotlight--------");
-                testSpotlight(test,  "c302.ADAL[0].v",'div[id="Plot2"]',true,false);
-            });
-        });
-    });
-
-    casper.then(function(){
-        casper.echo("-------Testing Spotlight--------");
-        testSpotlight(test,  "c302.ADAL[0].v",'div[id="Plot2"]',true,false);
-    });
-
-    casper.then(function(){
-        closeSpotlight(); //close spotlight before continuing
-        casper.echo("-------Testing Canvas Widget and Camera Controls for both canvas--------");
-        casper.evaluate(function(){
-            GEPPETTO.ComponentFactory.addWidget('CANVAS', {name: '3D Canvas',}, function () {this.setName('Widget Canvas');this.setPosition();this.display([c302])});
-            Plot1.setPosition(0,300);
-        });
-
-        testCameraControlsWithCanvasWidget(test,[49.25,-0.8000001907348633,733.3303486467378]);
-    });
-
-    casper.then(function(){
-        var initialColorFunctions = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        casper.echo("-------Testing Color Function--------");
-        //add color Function
-        casper.evaluate(function(){
-            GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
-            Project.getActiveExperiment().play({step:10});
-        });
-        var colorFunctionInstances = casper.evaluate(function(){
-            return GEPPETTO.SceneController.getColorFunctionInstances().length;
-        });
-        test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
-        //		//test color function
-        //		casper.wait(2000, function(){
-        //			test3DMeshColorNotEquals(test,defaultColor,"c302.PVDR[0]");
-        //		});
-        casper.echo("Done Playing, now exiting");
-    });
-}
-
-function ca1Test(test){
-    casper.then(function(){launchTest(test,"CA1",45000);});
-    casper.echo("------------STARTING CA1 TEST--------------");
-
-    casper.then(function () {
-        this.echo("Opening controls panel");
-        buttonClick("#controlPanelBtn");
-        casper.wait(10000, function(){});
-    });
-
-    casper.then(function(){
-        testInitialControlPanelValues(test,3);
-    });
-
-    casper.then(function(){
-        this.evaluate(function(){
-            $("#anyProjectFilterBtn").click();
-        });
-    });
-
-    casper.then(function(){
-        casper.evaluate(function() {
-            $("#controlpanel").hide();
+        test.assertEquals(rows, 10, "Correct amount of rows for Global filter");
+        casper.evaluate(function () {
+          $("#controlpanel").hide();
         });	
         casper.echo("-------Testing Spotlight--------");
-        testSpotlight(test,  "ca1.CA1_CG[0].Seg0_apical_dendrite_22_1158.v",'',false,false);
+        testSpotlight(test, "c302.ADAL[0].v",'div[id="Plot2"]',true,false);
+      });
+    });
+  });
+
+  casper.then(function (){
+    casper.echo("-------Testing Spotlight--------");
+    testSpotlight(test, "c302.ADAL[0].v",'div[id="Plot2"]',true,false);
+  });
+
+  casper.then(function (){
+    closeSpotlight(); // close spotlight before continuing
+    casper.echo("-------Testing Canvas Widget and Camera Controls for both canvas--------");
+    casper.evaluate(function (){
+      GEPPETTO.ComponentFactory.addWidget('CANVAS', { name: '3D Canvas', }, function () {
+        this.setName('Widget Canvas');this.setPosition();this.display([c302])
+      });
+      Plot1.setPosition(0,300);
     });
 
-    casper.then(function(){
-        closeSpotlight(); //close spotlight before continuing
+    testCameraControlsWithCanvasWidget(test,[49.25,-0.8000001907348633,733.3303486467378]);
+  });
+
+  casper.then(function (){
+    var initialColorFunctions = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
     });
-}
-
-function testPVDRNeuronProject(test){
-	casper.then(function(){launchTest(test,"PVDR cell NEURON",200000);});
-	casper.echo("------------STARTING PVDR Neuron TEST--------------");
-	casper.then(function () {
-		var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-		test.assertEquals(experiments, 1, "Initial amount of experiments for PVDR checked");
-	});
-    
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return window.Project.getActiveExperiment().getId();});
-		test.assertEquals(evaluate, 1, "PVDR Project.getActiveExperiment() checked");
-	});
-    
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return pvdr!=null;});
-		test.assertEquals(evaluate,true, "Top level PVDR instance present");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return pvdr.getConnections().length===0;
-		},"Connections checked for PVDR model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return pvdr.getVisualGroups().length===1;
-		},"Test number of VisualGroups for PVDR model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-            window.Model.getVariables()[0].getId() == 'pvdr' && window.Model.getVariables()[1].getId() == 'time';
-		},"2 top Variables as expected for PVDR model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-		},"2 Libraries as expected for PVDR model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'pvdr';
-		},"2 top level instance as expected for PVDR model");
-	});
-}
-
-function testPMuscleCellProject(test){
-	casper.then(function(){launchTest(test,"PMuscle cell NEURON",200000);});
-	casper.echo("------------STARTING PMuscle Model TEST--------------");
-	casper.waitForSelector('div[id="Popup1"]', function() {
-        this.echo("I've waited for Popup1 to load.");
-    }, null, 30000);
-	
-	casper.then(function () {
-		var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-		test.assertEquals(experiments, 1, "Initial amount of experiments for PVDR checked");
-	});
-    
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return window.Project.getActiveExperiment().getId();});
-		test.assertEquals(evaluate, 1, "PVDR Project.getActiveExperiment() checked");
-	});
-    
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return net1!=null;});
-		test.assertEquals(evaluate,true, "Top level net1 instance present for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		var evaluate = casper.evaluate(function() {return net1.getChildren().length;});
-		test.assertEquals(evaluate,2, "Children checked for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return net1.getConnections().length===0;
-		},"Connections checked for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return !net1.neuron[0].getVisualType().hasCapability('VisualGroupCapability');
-		},"Test No visual groups for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return net1.neuron[0].getVisualType().hasCapability('VisualCapability');
-		},"Visual capability on neuron for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return net1.muscle[0].getVisualType().hasCapability('VisualCapability');
-		},"Visual capability on muscle for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-            window.Model.getVariables()[0].getId() == 'net1' && window.Model.getVariables()[1].getId() == 'time';
-		},"2 top Variables as expected for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-		},"2 Libraries as expected for PMuscle Model");
-	});
-    
-    casper.then(function () {
-		test.assertEval(function() {
-			return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'net1';
-		},"2 top level instance as expected for for PMuscle Model");
-	});
-}
-
-function testC302Connectome(test){
-	casper.then(function(){launchTest(test,"C302 Connectome",200000);});
-    casper.echo("------------STARTING C302 Connectome TEST--------------");
-    casper.waitForSelector('div[id="Popup1"]', function() {
-        this.echo("I've waited for Popup1 to load.");
-    }, null, 150000);
-}
-
-
-function testCylindersProject(test){
-	casper.then(function(){launchTest(test,"Cylinders",200000);});
-	casper.echo("------------STARTING Cylinder Orientation TEST--------------");
-
-    casper.then(function () {
-
-        test.assertEval(function() {
-            var reference = {"Example2.Pop_OneSeg[0]":[0, Math.PI/2, 0, "XYZ"],
-                            "Example2.Pop_OneSeg[1]":[0, Math.PI/2, 0, "XYZ"],
-                            "Example2.Pop_TwoSeg[0]":[0, 0, 0, "XYZ"]};
-            var results = [];
-            for (var path in reference) {
-                var rotation = Canvas1.engine.meshes[path].rotation.toArray();
-                var expected = reference[path];
-                for (var i=0; i<rotation.length; ++i)
-                    results.push(rotation[i] === expected[i]);
-            }
-            for (var i=0; i<rotation.length; ++i)
-                results.push(rotation[i] === expected[i]);
-	    return results.every(function(x){return x;});
-	},"Rotation checked for all segments");
+    casper.echo("-------Testing Color Function--------");
+    // add color Function
+    casper.evaluate(function (){
+      GEPPETTO.SceneController.addColorFunction(GEPPETTO.ModelFactory.instances.getInstance(GEPPETTO.ModelFactory.getAllPotentialInstancesEndingWith('.v'),false), window.voltage_color);
+      Project.getActiveExperiment().play({ step:10 });
     });
+    var colorFunctionInstances = casper.evaluate(function (){
+      return GEPPETTO.SceneController.getColorFunctionInstances().length;
+    });
+    test.assertNotEquals(initialColorFunctions,colorFunctionInstances, "More than one color function instance found");
+    /*
+     * //test color function
+     * casper.wait(2000, function(){
+     * test3DMeshColorNotEquals(test,defaultColor,"c302.PVDR[0]");
+     * });
+     */
+    casper.echo("Done Playing, now exiting");
+  });
+}
+
+function ca1Test (test){
+  casper.then(function (){
+    launchTest(test,"CA1",45000);
+  });
+  casper.echo("------------STARTING CA1 TEST--------------");
+
+  casper.then(function () {
+    this.echo("Opening controls panel");
+    buttonClick("#controlPanelBtn");
+    casper.wait(10000, function (){});
+  });
+
+  casper.then(function (){
+    testInitialControlPanelValues(test,3);
+  });
+
+  casper.then(function (){
+    this.evaluate(function (){
+      $("#anyProjectFilterBtn").click();
+    });
+  });
+
+  casper.then(function (){
+    casper.evaluate(function () {
+      $("#controlpanel").hide();
+    });
+    casper.echo("-------Testing Spotlight--------");
+    testSpotlight(test, "ca1.CA1_CG[0].Seg0_apical_dendrite_22_1158.v",'',false,false);
+  });
+
+  casper.then(function (){
+    closeSpotlight(); // close spotlight before continuing
+  });
+}
+
+function testPVDRNeuronProject (test){
+  casper.then(function (){
+    launchTest(test,"PVDR cell NEURON",200000);
+  });
+  casper.echo("------------STARTING PVDR Neuron TEST--------------");
+  casper.then(function () {
+    var experiments = casper.evaluate(function () {
+      return window.Project.getExperiments().length;
+    });
+    test.assertEquals(experiments, 1, "Initial amount of experiments for PVDR checked");
+  });
+    
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return window.Project.getActiveExperiment().getId();
+    });
+    test.assertEquals(evaluate, 1, "PVDR Project.getActiveExperiment() checked");
+  });
+    
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return pvdr != null;
+    });
+    test.assertEquals(evaluate,true, "Top level PVDR instance present");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return pvdr.getConnections().length === 0;
+    },"Connections checked for PVDR model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return pvdr.getVisualGroups().length === 1;
+    },"Test number of VisualGroups for PVDR model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2
+            && window.Model.getVariables()[0].getId() == 'pvdr' && window.Model.getVariables()[1].getId() == 'time';
+    },"2 top Variables as expected for PVDR model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+    },"2 Libraries as expected for PVDR model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'pvdr';
+    },"2 top level instance as expected for PVDR model");
+  });
+}
+
+function testPMuscleCellProject (test){
+  casper.then(function (){
+    launchTest(test,"PMuscle cell NEURON",200000);
+  });
+  casper.echo("------------STARTING PMuscle Model TEST--------------");
+  casper.waitForSelector('div[id="Popup1"]', function () {
+    this.echo("I've waited for Popup1 to load.");
+  }, null, 30000);
+  
+  casper.then(function () {
+    var experiments = casper.evaluate(function () {
+      return window.Project.getExperiments().length;
+    });
+    test.assertEquals(experiments, 1, "Initial amount of experiments for PVDR checked");
+  });
+    
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return window.Project.getActiveExperiment().getId();
+    });
+    test.assertEquals(evaluate, 1, "PVDR Project.getActiveExperiment() checked");
+  });
+    
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return net1 != null;
+    });
+    test.assertEquals(evaluate,true, "Top level net1 instance present for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    var evaluate = casper.evaluate(function () {
+      return net1.getChildren().length;
+    });
+    test.assertEquals(evaluate,2, "Children checked for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return net1.getConnections().length === 0;
+    },"Connections checked for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return !net1.neuron[0].getVisualType().hasCapability('VisualGroupCapability');
+    },"Test No visual groups for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return net1.neuron[0].getVisualType().hasCapability('VisualCapability');
+    },"Visual capability on neuron for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return net1.muscle[0].getVisualType().hasCapability('VisualCapability');
+    },"Visual capability on muscle for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2
+            && window.Model.getVariables()[0].getId() == 'net1' && window.Model.getVariables()[1].getId() == 'time';
+    },"2 top Variables as expected for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+    },"2 Libraries as expected for PMuscle Model");
+  });
+    
+  casper.then(function () {
+    test.assertEval(function () {
+      return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'net1';
+    },"2 top level instance as expected for for PMuscle Model");
+  });
+}
+
+function testC302Connectome (test){
+  casper.then(function (){
+    launchTest(test,"C302 Connectome",200000);
+  });
+  casper.echo("------------STARTING C302 Connectome TEST--------------");
+  casper.waitForSelector('div[id="Popup1"]', function () {
+    this.echo("I've waited for Popup1 to load.");
+  }, null, 150000);
+}
+
+
+function testCylindersProject (test){
+  casper.then(function (){
+    launchTest(test,"Cylinders",200000);
+  });
+  casper.echo("------------STARTING Cylinder Orientation TEST--------------");
+
+  casper.then(function () {
+
+    test.assertEval(function () {
+      var reference = { 
+        "Example2.Pop_OneSeg[0]":[0, Math.PI / 2, 0, "XYZ"],
+        "Example2.Pop_OneSeg[1]":[0, Math.PI / 2, 0, "XYZ"],
+        "Example2.Pop_TwoSeg[0]":[0, 0, 0, "XYZ"]
+      };
+      var results = [];
+      for (var path in reference) {
+        var rotation = Canvas1.engine.meshes[path].rotation.toArray();
+        var expected = reference[path];
+        for (var i = 0; i < rotation.length; ++i) {
+          results.push(rotation[i] === expected[i]);
+        }
+      }
+      for (var i = 0; i < rotation.length; ++i) {
+        results.push(rotation[i] === expected[i]);
+      }
+      return results.every(function (x){
+        return x;
+      });
+    },"Rotation checked for all segments");
+  });
 }

--- a/tests/casperjs/PersistenceTests.js
+++ b/tests/casperjs/PersistenceTests.js
@@ -1,6 +1,6 @@
 var urlBase = casper.cli.get('host');
-if(urlBase==null || urlBase==undefined){
-	urlBase = "http://127.0.0.1:8080/";
+if (urlBase == null || urlBase == undefined){
+  urlBase = "http://127.0.0.1:8080/";
 }
 var PROJECT_URL_SUFFIX = "?load_project_from_url=https://raw.githubusercontent.com/openworm/org.geppetto.samples/development/UsedInUnitTests/SingleComponentHH/GEPPETTO.json";
 var PROJECT_URL_SUFFIX_2 = "?load_project_from_url=https://raw.githubusercontent.com/openworm/org.geppetto.samples/development/UsedInUnitTests/pharyngeal/project.json";
@@ -10,166 +10,174 @@ var projectID;
 
 var defaultLongWaitingTime = 295000;
 
-casper.test.begin('Geppetto basic tests', function suite(test) {
-    casper.options.viewportSize = {
-        width: 1340,
-        height: 768
-    };
+casper.test.begin('Geppetto basic tests', function suite (test) {
+  casper.options.viewportSize = {
+    width: 1340,
+    height: 768
+  };
 
-    // add for debug info
-    //casper.options.verbose = true;
-    //casper.options.logLevel = "debug";
+  /*
+   * add for debug info
+   * casper.options.verbose = true;
+   * casper.options.logLevel = "debug";
+   */
 
-    // show unhandled js errors
-    casper.on("page.error", function(msg, trace) {
-        this.echo("Error: " + msg, "ERROR");
+  // show unhandled js errors
+  casper.on("page.error", function (msg, trace) {
+    this.echo("Error: " + msg, "ERROR");
+  });
+
+  // show page level errors
+  casper.on('resource.received', function (resource) {
+    var status = resource.status;
+    if (status >= 400) {
+      this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
+      this.echo('URL: ' + resource.url + ' Body: ' + resource.status);
+    }
+  });
+
+  casper.start(urlBase + "org.geppetto.frontend", function () {
+    this.echo("Starting geppetto at host " + urlBase);
+    this.waitForSelector('div#logo', function () {
+      this.echo("I waited for the logo to load.");
+      test.assertTitle("geppetto's home", "geppetto's homepage title is the one expected");
+      test.assertExists('div#logo', "logo is found");
+    }, null, defaultLongWaitingTime);
+  });
+
+  casper.then(function () {
+    /*
+     * TODO: log back in as other users. Check more things
+     * TODO: exercise the run loop, check the changing experiment status, try to make experiment fail
+     */
+    casper.echo("Waiting to logout");
+    casper.thenOpen(urlBase + "org.geppetto.frontend/logout", function () {
+      this.echo("I've waited for user to logout.");
     });
-
-    // show page level errors
-    casper.on('resource.received', function (resource) {
-        var status = resource.status;
-        if (status >= 400) {
-            this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
-            this.echo('URL: ' + resource.url + ' Body: '  + resource.status);
-        }
-    });
-
-    casper.start(urlBase+"org.geppetto.frontend", function () {
-    	this.echo("Starting geppetto at host "+ urlBase);
-        this.waitForSelector('div#logo', function () {
-            this.echo("I waited for the logo to load.");
-            test.assertTitle("geppetto's home", "geppetto's homepage title is the one expected");
-            test.assertExists('div#logo', "logo is found");
-        }, null, defaultLongWaitingTime);
-    });
-
-    casper.then(function () {
-    	//TODO: log back in as other users. Check more things
-        //TODO: exercise the run loop, check the changing experiment status, try to make experiment fail
-        casper.echo("Waiting to logout");
-        casper.thenOpen(urlBase+"org.geppetto.frontend/logout", function () {
-        	this.echo("I've waited for user to logout.");
-        });
-    });
+  });
     
-    casper.then(function () {
-        casper.thenOpen(urlBase+"org.geppetto.frontend/login?username=guest1&password=guest", function () {
-        	this.echo("Starting geppetto at host login "+ urlBase);
-            /*this.waitForSelector('div#page', function() {
-             this.echo("I've waited for the splash screen to come up.");
-             test.assertUrlMatch(/splash$/, 'Virgo Splash Screen comes up indicating successful login');
-             }, null, 30000);*/
-        });
+  casper.then(function () {
+    casper.thenOpen(urlBase + "org.geppetto.frontend/login?username=guest1&password=guest", function () {
+      this.echo("Starting geppetto at host login " + urlBase);
+      /* 
+       * this.waitForSelector('div#page', function() {
+       * this.echo("I've waited for the splash screen to come up.");
+       * test.assertUrlMatch(/splash$/, 'Virgo Splash Screen comes up indicating successful login');
+       * }, null, 30000);
+       */
     });
+  });
     
-    casper.then(function () {
-        casper.thenOpen(urlBase+"org.geppetto.frontend", function () {
-            this.waitForSelector('div[project-id="2"]', function () {
-                this.echo("I've waited for the projects to load.");
-                test.assertExists('div#logo', "logo is found");
-                test.assertExists('div[project-id="2"]', "Projects from persistence bundle are present")
-                test.assertSelectorHasText('div.user', 'Guest user', "Guest user is logged in");
-            }, null, 100000);
+  casper.then(function () {
+    casper.thenOpen(urlBase + "org.geppetto.frontend", function () {
+      this.waitForSelector('div[project-id="2"]', function () {
+        this.echo("I've waited for the projects to load.");
+        test.assertExists('div#logo', "logo is found");
+        test.assertExists('div[project-id="2"]', "Projects from persistence bundle are present")
+        test.assertSelectorHasText('div.user', 'Guest user', "Guest user is logged in");
+      }, null, 100000);
             
-            this.waitForSelector('div[project-id="1"]', function () {
-                this.echo("I've waited for the projects to load.");
-                test.assertExists('div#logo', "logo is found");
-                test.assertExists('div[project-id="1"]', "Projects from persistence bundle are present")
-                test.assertSelectorHasText('div.user', 'Guest user', "Guest user is logged in");
-            }, null, 100000);
-        });
+      this.waitForSelector('div[project-id="1"]', function () {
+        this.echo("I've waited for the projects to load.");
+        test.assertExists('div#logo', "logo is found");
+        test.assertExists('div[project-id="1"]', "Projects from persistence bundle are present")
+        test.assertSelectorHasText('div.user', 'Guest user', "Guest user is logged in");
+      }, null, 100000);
     });
-    casper.then(function () {
-        testProject(test, urlBase+"org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX, true,
-            false, 'hhcell.hhpop[0].v', 'Model.neuroml.pulseGen1.delay', true,"hhcell");
-    });
+  });
+  casper.then(function () {
+    testProject(test, urlBase + "org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX, true,
+      false, 'hhcell.hhpop[0].v', 'Model.neuroml.pulseGen1.delay', true,"hhcell");
+  });
     
-    casper.then(function () {
-    	projectID = this.evaluate(function() {
-           return Project.getId();
-        });
-    	this.echo("Project id to delete : "+projectID);
+  casper.then(function () {
+    projectID = this.evaluate(function () {
+      return Project.getId();
     });
+    this.echo("Project id to delete : " + projectID);
+  });
     
-    casper.then(function () {
-        reloadProjectTest(test, urlBase+"org.geppetto.frontend/geppetto?load_project_from_id="+projectID,1);
-    });
+  casper.then(function () {
+    reloadProjectTest(test, urlBase + "org.geppetto.frontend/geppetto?load_project_from_id=" + projectID,1);
+  });
     
-    casper.then(function () {
-        deleteProject(test, urlBase+"org.geppetto.frontend",projectID);
-    });
+  casper.then(function () {
+    deleteProject(test, urlBase + "org.geppetto.frontend",projectID);
+  });
  
-    casper.then(function () {
-        testProject(test, urlBase+"org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX_2, false,
-            false, 'c302_A_Pharyngeal.M1[0].v', 'Model.neuroml.generic_neuron_iaf_cell.C', false,"c302_A_Pharyngeal");
-    });
+  casper.then(function () {
+    testProject(test, urlBase + "org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX_2, false,
+      false, 'c302_A_Pharyngeal.M1[0].v', 'Model.neuroml.generic_neuron_iaf_cell.C', false,"c302_A_Pharyngeal");
+  });
     
-    casper.then(function () {
-    	projectID = this.evaluate(function() {
-           return Project.getId();
-        });
-    	this.echo("Project id to delete : "+projectID);
+  casper.then(function () {
+    projectID = this.evaluate(function () {
+      return Project.getId();
     });
+    this.echo("Project id to delete : " + projectID);
+  });
     
-    casper.then(function () {
-        reloadProjectTest(test, urlBase+"org.geppetto.frontend/geppetto?load_project_from_id="+projectID,1);
-    });
+  casper.then(function () {
+    reloadProjectTest(test, urlBase + "org.geppetto.frontend/geppetto?load_project_from_id=" + projectID,1);
+  });
     
-    casper.then(function () {
-        deleteProject(test, urlBase+"org.geppetto.frontend",projectID);
-    });
+  casper.then(function () {
+    deleteProject(test, urlBase + "org.geppetto.frontend",projectID);
+  });
 
-    casper.then(function () {
-        testProject(test, urlBase+"org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX_3, false,
-            false, '', '', false,"Balanced_240cells_36926conns");
-    });
+  casper.then(function () {
+    testProject(test, urlBase + "org.geppetto.frontend/geppetto" + PROJECT_URL_SUFFIX_3, false,
+      false, '', '', false,"Balanced_240cells_36926conns");
+  });
     
-    casper.then(function () {
-    	projectID = this.evaluate(function() {
-           return Project.getId();
-        });
-    	this.echo("Project id to delete : "+projectID);
+  casper.then(function () {
+    projectID = this.evaluate(function () {
+      return Project.getId();
     });
+    this.echo("Project id to delete : " + projectID);
+  });
     
-    casper.then(function () {
-        reloadProjectTest(test, urlBase+"org.geppetto.frontend/geppetto?load_project_from_id="+projectID,1);
-    });
-   
-    casper.then(function () {
-        deleteProject(test, urlBase+"org.geppetto.frontend",projectID);
-    });
-    
-    //tests persistence project features
-    casper.then(function () {
-        testPersistedProjectFeatures(test, urlBase+"org.geppetto.frontend/geppetto?load_project_from_id=1");
-    });
-    
-    casper.then(function () {
-    	//TODO: log back in as other users. Check more things
-        //TODO: exercise the run loop, check the changing experiment status, try to make experiment fail
-        casper.echo("Waiting to logout");
-        casper.thenOpen(urlBase+"org.geppetto.frontend/logout", function () {
-        	this.echo("I've waited for user to logout.");
-        });
-    });
+  casper.then(function () {
+    reloadProjectTest(test, urlBase + "org.geppetto.frontend/geppetto?load_project_from_id=" + projectID,1);
+  });
 
-    casper.then(function () {
-    	casper.echo("Waiting for admin to login");
-        casper.thenOpen(urlBase+"org.geppetto.frontend/login?username=admin&password=admin", function () {
-        	this.echo("I've waited for the admin user to log");
-        });
-    });
+  casper.then(function () {
+    deleteProject(test, urlBase + "org.geppetto.frontend",projectID);
+  });
     
-    casper.then(function () {
-    	casper.echo("Waiting for admin panel");
-        casper.thenOpen(urlBase+"org.geppetto.frontend/admin", function () {
-            this.waitForSelector('div[class="griddle"]', function () {
-                this.echo("I've waited for the admin panel to load.");
-            }, null, 30000);
-        });
-    });  
+  // tests persistence project features
+  casper.then(function () {
+    testPersistedProjectFeatures(test, urlBase + "org.geppetto.frontend/geppetto?load_project_from_id=1");
+  });
     
-    casper.run(function () {
-        test.done();
+  casper.then(function () {
+    /*
+     * TODO: log back in as other users. Check more things
+     * TODO: exercise the run loop, check the changing experiment status, try to make experiment fail
+     */
+    casper.echo("Waiting to logout");
+    casper.thenOpen(urlBase + "org.geppetto.frontend/logout", function () {
+      this.echo("I've waited for user to logout.");
     });
+  });
+
+  casper.then(function () {
+    casper.echo("Waiting for admin to login");
+    casper.thenOpen(urlBase + "org.geppetto.frontend/login?username=admin&password=admin", function () {
+      this.echo("I've waited for the admin user to log");
+    });
+  });
+    
+  casper.then(function () {
+    casper.echo("Waiting for admin panel");
+    casper.thenOpen(urlBase + "org.geppetto.frontend/admin", function () {
+      this.waitForSelector('div[class="griddle"]', function () {
+        this.echo("I've waited for the admin panel to load.");
+      }, null, 30000);
+    });
+  });  
+    
+  casper.run(function () {
+    test.done();
+  });
 });

--- a/tests/casperjs/PersistenceTestsLogic.js
+++ b/tests/casperjs/PersistenceTestsLogic.js
@@ -1,881 +1,905 @@
 var amountOfRuns = 10;
-var dropBoxURL="https://www.dropbox.com/1/oauth2/authorize?locale=en_US&client_id=kbved8e6wnglk4h&response_type=code";
+var dropBoxURL = "https://www.dropbox.com/1/oauth2/authorize?locale=en_US&client_id=kbved8e6wnglk4h&response_type=code";
 var code;
 var permissions;
 
 var dropboxcode = casper.cli.get('dropboxcode');
 
-function deleteProject(test, url,id){
-	casper.thenOpen(url, function () {
-		this.echo("Loading an external model that is persisted at " + url);
+function deleteProject (test, url,id){
+  casper.thenOpen(url, function () {
+    this.echo("Loading an external model that is persisted at " + url);
 
-		casper.then(function () {
-			this.waitForSelector("div.project-preview", function () {
-				this.echo("Dashboard loaded")
-			}, null, 10000);
-		});
+    casper.then(function () {
+      this.waitForSelector("div.project-preview", function () {
+        this.echo("Dashboard loaded")
+      }, null, 10000);
+    });
 
-		casper.then(function(){
-			casper.evaluate(function() {
-				$("#projects").scrollTop($("#projects")[0].scrollHeight+1000);
-			});
-		});
+    casper.then(function (){
+      casper.evaluate(function () {
+        $("#projects").scrollTop($("#projects")[0].scrollHeight + 1000);
+      });
+    });
 
-		casper.then(function () {
-			this.waitForSelector('div[project-id=\"'+id+'\"]', function (id) {
-				this.echo("Waited for scrolldown projects to appear");
-				this.mouse.click('div[project-id=\"'+id+'\"]');
-			}, id, 4000);
-		});
+    casper.then(function () {
+      this.waitForSelector('div[project-id=\"' + id + '\"]', function (id) {
+        this.echo("Waited for scrolldown projects to appear");
+        this.mouse.click('div[project-id=\"' + id + '\"]');
+      }, id, 4000);
+    });
 
-		casper.then(function () {
-			this.waitForSelector('a[title=\"Delete project\"]', function () {
-				this.echo("Waited for delete icon to delete project");
-				this.mouse.click("i.fa-trash-o");
-			}, null, 15000);
+    casper.then(function () {
+      this.waitForSelector('a[title=\"Delete project\"]', function () {
+        this.echo("Waited for delete icon to delete project");
+        this.mouse.click("i.fa-trash-o");
+      }, null, 15000);
 
-			this.waitWhileVisible('a[title=\"Open project\"]', function () {
-				test.assertNotVisible('a[title=\"Open project\"]', "Correctly deleted project " + id);
-			}, null, 30000);
-		});
-	});
+      this.waitWhileVisible('a[title=\"Open project\"]', function () {
+        test.assertNotVisible('a[title=\"Open project\"]', "Correctly deleted project " + id);
+      }, null, 30000);
+    });
+  });
 }
 
 
-function reloadProjectTest(test, url, customHandlers,widgetCanvasObject){
-	casper.thenOpen(url, function () {
-		this.echo("Reloading persisted project at " + url);
+function reloadProjectTest (test, url, customHandlers,widgetCanvasObject){
+  casper.thenOpen(url, function () {
+    this.echo("Reloading persisted project at " + url);
 
-		casper.waitWhileVisible('div[id="loading-spinner"]', function () {
-			this.echo("I've waited for "+url+" project to load.");
+    casper.waitWhileVisible('div[id="loading-spinner"]', function () {
+      this.echo("I've waited for " + url + " project to load.");
 
-			casper.waitForSelector('div#Popup1', function() {
-				test.assertVisible('div#Popup1', "Popup1 is correctly open on reload");
-			}, null, defaultLongWaitingTime);
+      casper.waitForSelector('div#Popup1', function () {
+        test.assertVisible('div#Popup1', "Popup1 is correctly open on reload");
+      }, null, defaultLongWaitingTime);
 
-			casper.waitForSelector('div#Connectivity1', function() {
-				test.assertVisible('div#Connectivity1', "Connectivity1 is correctly open on reload");
-			}, null, defaultLongWaitingTime);
+      casper.waitForSelector('div#Connectivity1', function () {
+        test.assertVisible('div#Connectivity1', "Connectivity1 is correctly open on reload");
+      }, null, defaultLongWaitingTime);
 
-			casper.waitForSelector('div#Canvas2', function() {
-				test.assertVisible('div#Canvas2', "Canvas2 is correctly open on reload.");
+      casper.waitForSelector('div#Canvas2', function () {
+        test.assertVisible('div#Canvas2', "Canvas2 is correctly open on reload.");
 
-				if(casper.exists('#tutorialBtn')){
-					test.assertVisible('div#Tutorial1', "Tutorial1 is correctly open on reload");
+        if (casper.exists('#tutorialBtn')){
+          test.assertVisible('div#Tutorial1', "Tutorial1 is correctly open on reload");
 
-					var tutorialStep = casper.evaluate(function() {
-						return Tutorial1.state.currentStep;
-					});
+          var tutorialStep = casper.evaluate(function () {
+            return Tutorial1.state.currentStep;
+          });
 
-					test.assertEquals(tutorialStep, 2, "Tutorial1 step restored correctly");
-				}
+          test.assertEquals(tutorialStep, 2, "Tutorial1 step restored correctly");
+        }
 
-				var popUpCustomHandler = casper.evaluate(function() {
-					return Popup1.customHandlers;
-				});
+        var popUpCustomHandler = casper.evaluate(function () {
+          return Popup1.customHandlers;
+        });
 
-				test.assertEquals(popUpCustomHandler.length, customHandlers, "Popup1 custom handlers restored correctly");
-				test.assertEquals(popUpCustomHandler[0]["event"], "click", "Popup2 custom handlers event restored correctly");
+        test.assertEquals(popUpCustomHandler.length, customHandlers, "Popup1 custom handlers restored correctly");
+        test.assertEquals(popUpCustomHandler[0]["event"], "click", "Popup2 custom handlers event restored correctly");
 
-				var meshInCanvas2Exists = casper.evaluate(function() {
-					var mesh = $.isEmptyObject(Canvas1.engine.meshes);
+        var meshInCanvas2Exists = casper.evaluate(function () {
+          var mesh = $.isEmptyObject(Canvas1.engine.meshes);
 
-					return mesh;
-				});
+          return mesh;
+        });
 
-				test.assertEquals(meshInCanvas2Exists, false, "Canvas2 has mesh set correctly");
-			}, null, defaultLongWaitingTime);
-		},null,defaultLongWaitingTime);
-	});
+        test.assertEquals(meshInCanvas2Exists, false, "Canvas2 has mesh set correctly");
+      }, null, defaultLongWaitingTime);
+    },null,defaultLongWaitingTime);
+  });
 }
 
-function testProject(test, url, expect_error, persisted, spotlight_record_variable, spotlight_set_parameter, testConsole,widgetCanvasObject) {
+function testProject (test, url, expect_error, persisted, spotlight_record_variable, spotlight_set_parameter, testConsole,widgetCanvasObject) {
 
-	casper.thenOpen(url, function () {
-		this.echo("Loading an external model that is not persisted at " + url);
+  casper.thenOpen(url, function () {
+    this.echo("Loading an external model that is not persisted at " + url);
 
-		casper.then(function () {
-			casper.waitWhileVisible('div[id="loading-spinner"]', function () {
-				this.echo("I've waited for "+url+" project to load.");
-				test.assertTitle("geppetto", "geppetto title is ok");
-				test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
-				test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
-				test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
-			},null,defaultLongWaitingTime);
-		});
+    casper.then(function () {
+      casper.waitWhileVisible('div[id="loading-spinner"]', function () {
+        this.echo("I've waited for " + url + " project to load.");
+        test.assertTitle("geppetto", "geppetto title is ok");
+        test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
+        test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
+        test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
+      },null,defaultLongWaitingTime);
+    });
 
-		casper.then(function () {
-			if (expect_error) {
-				casper.then(function () {
-					closeErrorMesage(test)
-				});
-			}
+    casper.then(function () {
+      if (expect_error) {
+        casper.then(function () {
+          closeErrorMesage(test)
+        });
+      }
 
-			casper.then(function () {
-				doExperimentTableTest(test);
-				//FIXME Restore after fixing console test
-				if(testConsole){
-					doConsoleTest(test);
-				}
-			});
+      casper.then(function () {
+        doExperimentTableTest(test);
+        // FIXME Restore after fixing console test
+        if (testConsole){
+          doConsoleTest(test);
+        }
+      });
 
-			casper.then(function () {
-				this.waitForSelector('tr.experimentsTableColumn:nth-child(1)', function () {
-					test.assertExists('tr.experimentsTableColumn:nth-child(1)', "At least one experiment row exists");
-				}, null, 60000);
-			});
+      casper.then(function () {
+        this.waitForSelector('tr.experimentsTableColumn:nth-child(1)', function () {
+          test.assertExists('tr.experimentsTableColumn:nth-child(1)', "At least one experiment row exists");
+        }, null, 60000);
+      });
 
-			//do checks on the state of the project if it is not persisted
-			if (persisted == false) {
-				casper.then(function () {
-					// make sure experiment panel is open
-					// casper.clickLabel('Experiments', 'span');
+      // do checks on the state of the project if it is not persisted
+      if (persisted == false) {
+        casper.then(function () {
+          /*
+           * make sure experiment panel is open
+           * casper.clickLabel('Experiments', 'span');
+           */
 
-					//roll over the experiments row
-					this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
-				});
+          // roll over the experiments row
+          this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
+        });
 
-				casper.then(function () {
-					if(casper.exists('#tutorialBtn')){
-						casper.mouseEvent('click', 'button#tutorialBtn', "attempting to open tutorial");
-					}
-					casper.evaluate(function(widgetCanvasObject) {
-						var canvasObject = null;
-						if(widgetCanvasObject=="hhcell"){
-							canvasObject = hhcell;
-						}else if(widgetCanvasObject=="c302_A_Pharyngeal"){
-							canvasObject = c302_A_Pharyngeal;
-						}else if(widgetCanvasObject=="Balanced_240cells_36926conns"){
-							canvasObject = Balanced_240cells_36926conns;
-						}
-						G.addWidget(6);
-						GEPPETTO.ComponentFactory.addWidget('CANVAS', {name: '3D Canvas',}, function () {this.setName('Widget Canvas');this.setPosition();this.display([canvasObject])});
-						G.addWidget(1).then(w=>{w.setMessage("Hhcell popup").addCustomNodeHandler(function(){},'click');});
-						$(".nextBtn").click();
-						$(".nextBtn").click();
-					},widgetCanvasObject);
-				});
-				casper.then(function () {
-					this.echo("Checking content of experiment row");
-					// test or wait for control panel stuff to be there
-					if(this.exists('span[class*="tabber"]')){
-						doExperimentsTableRowTests(test);
-					} else {
-						this.waitForSelector('span[class*="tabber"]', function(){
-							doExperimentsTableRowTests(test);
-						}, null, 10000);
-					}
-					//roll over the experiments row
-					this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
-					//doPrePersistenceExperimentsTableButtonsCheck(test);
-				});
-				casper.then(function () {
-					if(spotlight_record_variable != ''){
-						doPrePersistenceSpotlightCheckRecordedVariables(test, spotlight_record_variable);
-					}
-				});
-				casper.then(function () {
-					if(spotlight_set_parameter != '') {
-						doPrePersistenceSpotlightCheckSetParameters(test, spotlight_set_parameter);
-					}
-				});
+        casper.then(function () {
+          if (casper.exists('#tutorialBtn')){
+            casper.mouseEvent('click', 'button#tutorialBtn', "attempting to open tutorial");
+          }
+          casper.evaluate(function (widgetCanvasObject) {
+            var canvasObject = null;
+            if (widgetCanvasObject == "hhcell"){
+              canvasObject = hhcell;
+            } else if (widgetCanvasObject == "c302_A_Pharyngeal"){
+              canvasObject = c302_A_Pharyngeal;
+            } else if (widgetCanvasObject == "Balanced_240cells_36926conns"){
+              canvasObject = Balanced_240cells_36926conns;
+            }
+            G.addWidget(6);
+            GEPPETTO.ComponentFactory.addWidget('CANVAS', { name: '3D Canvas', }, function () {
+              this.setName('Widget Canvas');this.setPosition();this.display([canvasObject])
+            });
+            G.addWidget(1).then(w => {
+              w.setMessage("Hhcell popup").addCustomNodeHandler(function (){},'click');
+            });
+            $(".nextBtn").click();
+            $(".nextBtn").click();
+          },widgetCanvasObject);
+        });
+        casper.then(function () {
+          this.echo("Checking content of experiment row");
+          // test or wait for control panel stuff to be there
+          if (this.exists('span[class*="tabber"]')){
+            doExperimentsTableRowTests(test);
+          } else {
+            this.waitForSelector('span[class*="tabber"]', function (){
+              doExperimentsTableRowTests(test);
+            }, null, 10000);
+          }
+          // roll over the experiments row
+          this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
+          // doPrePersistenceExperimentsTableButtonsCheck(test);
+        });
+        casper.then(function () {
+          if (spotlight_record_variable != ''){
+            doPrePersistenceSpotlightCheckRecordedVariables(test, spotlight_record_variable);
+          }
+        });
+        casper.then(function () {
+          if (spotlight_set_parameter != '') {
+            doPrePersistenceSpotlightCheckSetParameters(test, spotlight_set_parameter);
+          }
+        });
 
-				casper.then(function () {
-					casper.wait(5000, function () {});
-				});
+        casper.then(function () {
+          casper.wait(5000, function () {});
+        });
 
-				casper.then(function () {
-					this.waitForSelector('button.btn.SaveButton', function () {
-						test.assertVisible('button.btn.SaveButton', "Persist button is present");
-					});
+        casper.then(function () {
+          this.waitForSelector('button.btn.SaveButton', function () {
+            test.assertVisible('button.btn.SaveButton', "Persist button is present");
+          });
 
-					//Not really testing anything
-					/*//Good pattern for checking the absence of an attribute
-                    test.assertEvalEquals(function () {
-                        return require('../../utils').dump(this.getElementAttribute('button.SaveButton', 'disabled'));
-                    }, null, "The persist button is correctly active.");*/
+          // Not really testing anything
+          /*
+           * //Good pattern for checking the absence of an attribute
+           * test.assertEvalEquals(function () {
+           * return require('../../utils').dump(this.getElementAttribute('button.SaveButton', 'disabled'));
+           * }, null, "The persist button is correctly active.");
+           */
 
-					//Click persist button. Check things again
-					this.mouseEvent('click', 'button.btn.SaveButton', "attempting to persist");
+          // Click persist button. Check things again
+          this.mouseEvent('click', 'button.btn.SaveButton', "attempting to persist");
 
-				});
+        });
 
-				//TODO: make this work
-				//this.mouseEvent('click', 'button[data-reactid=".9.4"]', "Running an experiment");
+        /*
+         * TODO: make this work
+         * this.mouseEvent('click', 'button[data-reactid=".9.4"]', "Running an experiment");
+         */
 
-				//TODO: Test indicator light during experiment run
-				//TODO: test experiment buttons again to see if they are in the right configuration after simulation run
+        /*
+         * TODO: Test indicator light during experiment run
+         * TODO: test experiment buttons again to see if they are in the right configuration after simulation run
+         */
 
-				//TODO: Clone an experiment and see if it has the right state and changes the state correctly for the other experiment rows
+        // TODO: Clone an experiment and see if it has the right state and changes the state correctly for the other experiment rows
 
-			}
+      }
 
-			casper.then(function () {
-				test.assertExists("button.btn.SaveButton[disabled]", "The persist button is now correctly inactive");
-			});
-			casper.then(function () {
-				this.echo("Waiting for persist star to stop spinning");
-				casper.waitWhileSelector('button.btn.SaveButton > i.fa-spin', function () {
-					//roll over the experiments row
-					this.echo("Persist star to stopped spinning");
-					//doPostPersistenceExperimentsTableButtonCheck(test);
-				}, null, defaultLongWaitingTime);
-			});
-			casper.then(function () {
-				doPostPersistenceSpotlightCheckSetParameters(test, spotlight_set_parameter);
-				//TODO: set a variable to record and a parameter to watch and make sure
-				//the experiment table row updates correctly.
-				//TODO: logout
-			});
-		});
-	});
+      casper.then(function () {
+        test.assertExists("button.btn.SaveButton[disabled]", "The persist button is now correctly inactive");
+      });
+      casper.then(function () {
+        this.echo("Waiting for persist star to stop spinning");
+        casper.waitWhileSelector('button.btn.SaveButton > i.fa-spin', function () {
+          // roll over the experiments row
+          this.echo("Persist star to stopped spinning");
+          // doPostPersistenceExperimentsTableButtonCheck(test);
+        }, null, defaultLongWaitingTime);
+      });
+      casper.then(function () {
+        doPostPersistenceSpotlightCheckSetParameters(test, spotlight_set_parameter);
+        /*
+         * TODO: set a variable to record and a parameter to watch and make sure
+         * the experiment table row updates correctly.
+         * TODO: logout
+         */
+      });
+    });
+  });
 }
 
-function closeErrorMesage(test) {
-	casper.waitUntilVisible('div.modal-content', function () {
-		this.echo("I've waited for the popup message to load up");
-		test.assertVisible('h3.text-center', "Error message correctly pops up");
-		test.assertSelectorHasText('h3.text-center', 'Message', "Error message correctly pops up with the message header");
-		this.mouseEvent('click', 'button.btn', "closing error message");
-		this.waitWhileVisible('h3.text-center', function () {
-			test.assertNotVisible('h3.text-center', "Correctly closed error message");
-		}, null, 30000);
-	}, null, 20000);
+function closeErrorMesage (test) {
+  casper.waitUntilVisible('div.modal-content', function () {
+    this.echo("I've waited for the popup message to load up");
+    test.assertVisible('h3.text-center', "Error message correctly pops up");
+    test.assertSelectorHasText('h3.text-center', 'Message', "Error message correctly pops up with the message header");
+    this.mouseEvent('click', 'button.btn', "closing error message");
+    this.waitWhileVisible('h3.text-center', function () {
+      test.assertNotVisible('h3.text-center', "Correctly closed error message");
+    }, null, 30000);
+  }, null, 20000);
 }
 
-function doExperimentTableTest(test) {
-	casper.then(function () {
-		test.assertExists('span[class*="tabber"]', "Experiments tab anchor is present");
+function doExperimentTableTest (test) {
+  casper.then(function () {
+    test.assertExists('span[class*="tabber"]', "Experiments tab anchor is present");
 
-		test.assertSelectorHasText('span[class*="tabber"]', 'Experiments');
+    test.assertSelectorHasText('span[class*="tabber"]', 'Experiments');
 
-		test.assertExists('div#experimentsOutput', "Experiments panel is present");
+    test.assertExists('div#experimentsOutput', "Experiments panel is present");
 
-		test.assertNotVisible('div#experimentsOutput', "The experiment panel is correctly closed.");
-	});
+    test.assertNotVisible('div#experimentsOutput', "The experiment panel is correctly closed.");
+  });
 
-	casper.then(function () {
-		this.echo("Opening experiment console");
-		casper.clickLabel('Experiments', 'span');
+  casper.then(function () {
+    this.echo("Opening experiment console");
+    casper.clickLabel('Experiments', 'span');
 
-		this.waitUntilVisible('div#experimentsOutput', function () {
-			test.assertVisible('div#experimentsOutput', "The experiment panel is correctly open.");
-			this.echo("Closing experiment console");
-			casper.clickLabel('Experiments', 'span');
-		}, null, 15000);
-	});
+    this.waitUntilVisible('div#experimentsOutput', function () {
+      test.assertVisible('div#experimentsOutput', "The experiment panel is correctly open.");
+      this.echo("Closing experiment console");
+      casper.clickLabel('Experiments', 'span');
+    }, null, 15000);
+  });
 }
 
-function doExperimentsTableRowTests(test){
-	casper.echo("Opening experiments panel");
-	casper.clickLabel('Experiments', 'span');
+function doExperimentsTableRowTests (test){
+  casper.echo("Opening experiments panel");
+  casper.clickLabel('Experiments', 'span');
 
-	// open first experiment row
-	casper.echo("Opening first experiment row");
-	casper.evaluate(function() {
-		$('tr.experimentsTableColumn:nth-child(1)').click();
-	});
+  // open first experiment row
+  casper.echo("Opening first experiment row");
+  casper.evaluate(function () {
+    $('tr.experimentsTableColumn:nth-child(1)').click();
+  });
 
-	casper.echo("Waiting for row contents to appear");
-	// make sure panel is open
-	casper.evaluate(function() {
-		if(!$('#experimentsOutput').is(':visible')){
-			//$('#experimentsButton').click();
-			//this.echo("Closing experiment console");
-			casper.clickLabel('Experiments', 'span');
-		}
-	});
-	casper.waitUntilVisible('td[name=variables]', function(){
-		test.assertVisible('td[name=variables]', "Variables column content exists");
-		test.assertVisible('td[name=parameters]', "Parameters column content exists");
-	}, null, 10000);
+  casper.echo("Waiting for row contents to appear");
+  // make sure panel is open
+  casper.evaluate(function () {
+    if (!$('#experimentsOutput').is(':visible')){
+      /*
+       * $('#experimentsButton').click();
+       * this.echo("Closing experiment console");
+       */
+      casper.clickLabel('Experiments', 'span');
+    }
+  });
+  casper.waitUntilVisible('td[name=variables]', function (){
+    test.assertVisible('td[name=variables]', "Variables column content exists");
+    test.assertVisible('td[name=parameters]', "Parameters column content exists");
+  }, null, 10000);
 }
 
-function doConsoleTest(test) {
+function doConsoleTest (test) {
 
-	casper.then(function () {
-		test.assertExists('span[class*="tabber"]', "Tabber anchor is present");
+  casper.then(function () {
+    test.assertExists('span[class*="tabber"]', "Tabber anchor is present");
 
-		test.assertSelectorHasText('span[class*="tabber"]', 'Console');
+    test.assertSelectorHasText('span[class*="tabber"]', 'Console');
 
-		test.assertExists('div[class*="consoleContainer"]', "Console panel is present");
+    test.assertExists('div[class*="consoleContainer"]', "Console panel is present");
 
-		test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly closed.");
-	});
+    test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly closed.");
+  });
 
-	casper.then(function () {
-		//this.click('a[href="#console"]', "Opening command console");
-		casper.clickLabel('Console', 'span');
+  casper.then(function () {
+    // this.click('a[href="#console"]', "Opening command console");
+    casper.clickLabel('Console', 'span');
 
-		this.waitUntilVisible('div.consoleContainer', function () {
-			test.assertVisible('div.consoleContainer', "The console panel is correctly open.");
-			//type into console command (getTimeSeries()) half finished for state variable
-			casper.evaluate(function() {
-				$('textarea#commandInputArea').val('hhcell.hhpop[0].v.getTi');
-				$('textarea#commandInputArea').trigger('keydown');
-			});
-			casper.wait(200, function () {
-				var nameCount = casper.evaluate(function () {
-					//retrieve console input via jquery
-					var output = $('textarea#commandInputArea').val();
-					return output;
-				});
-				casper.echo(nameCount);
-				//console should return command fully finished after autocomplete kicks in
-				test.assertEquals(nameCount, "hhcell.hhpop[0].v.getTimeSeries()", "Autocomplete for state variable present.");
+    this.waitUntilVisible('div.consoleContainer', function () {
+      test.assertVisible('div.consoleContainer', "The console panel is correctly open.");
+      // type into console command (getTimeSeries()) half finished for state variable
+      casper.evaluate(function () {
+        $('textarea#commandInputArea').val('hhcell.hhpop[0].v.getTi');
+        $('textarea#commandInputArea').trigger('keydown');
+      });
+      casper.wait(200, function () {
+        var nameCount = casper.evaluate(function () {
+          // retrieve console input via jquery
+          var output = $('textarea#commandInputArea').val();
+          return output;
+        });
+        casper.echo(nameCount);
+        // console should return command fully finished after autocomplete kicks in
+        test.assertEquals(nameCount, "hhcell.hhpop[0].v.getTimeSeries()", "Autocomplete for state variable present.");
 
-				casper.sendKeys('textarea#commandInputArea', "", {reset: true});
-			});
-		}, null, 5000);
-	});
+        casper.sendKeys('textarea#commandInputArea', "", { reset: true });
+      });
+    }, null, 5000);
+  });
 
-	casper.then(function () {
-		//type into console command (isSelected()) half finished for object, if
-		//updated capability worked then isSelected() method from object VisualCapability
-		//will be part of object hhcell
-		casper.evaluate(function() {
-			$('textarea#commandInputArea').val('hhcell.isS');
-			$('textarea#commandInputArea').trigger('keydown');
-		});
-		casper.wait(200, function () {
-			var nameCount = casper.evaluate(function () {
-				//retrieve console input via jquery
-				var output = $('textarea#commandInputArea').val();
-				return output;
-			});
-			casper.echo(nameCount);
-			//console should return command fully finished after autocomplete kicks in
-			test.assertEquals(nameCount, "hhcell.isSelected()", "Autocomplete for updated capability present.");
+  casper.then(function () {
+    /*
+     * type into console command (isSelected()) half finished for object, if
+     * updated capability worked then isSelected() method from object VisualCapability
+     * will be part of object hhcell
+     */
+    casper.evaluate(function () {
+      $('textarea#commandInputArea').val('hhcell.isS');
+      $('textarea#commandInputArea').trigger('keydown');
+    });
+    casper.wait(200, function () {
+      var nameCount = casper.evaluate(function () {
+        // retrieve console input via jquery
+        var output = $('textarea#commandInputArea').val();
+        return output;
+      });
+      casper.echo(nameCount);
+      // console should return command fully finished after autocomplete kicks in
+      test.assertEquals(nameCount, "hhcell.isSelected()", "Autocomplete for updated capability present.");
 
-			casper.sendKeys('textarea#commandInputArea', "", {reset: true});
-		});
-	});
+      casper.sendKeys('textarea#commandInputArea', "", { reset: true });
+    });
+  });
 }
 
-function doPrePersistenceExperimentsTableButtonsCheck(test) {
-	//Check presence of experiment console buttons before persistence
-	casper.waitForSelector('a.activeIcon', function () {
-		test.assertNotVisible('a.activeIcon', "active button exists and is correctly not enabled");
-	}, null, 10000);
+function doPrePersistenceExperimentsTableButtonsCheck (test) {
+  // Check presence of experiment console buttons before persistence
+  casper.waitForSelector('a.activeIcon', function () {
+    test.assertNotVisible('a.activeIcon', "active button exists and is correctly not enabled");
+  }, null, 10000);
 
-	casper.waitForSelector('a.deleteIcon', function () {
-		test.assertDoesntExist('a.enabled.deleteIcon', "delete button exists and is correctly not enabled");
-	}, null, 10000);
+  casper.waitForSelector('a.deleteIcon', function () {
+    test.assertDoesntExist('a.enabled.deleteIcon', "delete button exists and is correctly not enabled");
+  }, null, 10000);
 
-	casper.waitForSelector('a.downloadResultsIcon', function () {
-		test.assertNotVisible('a.downloadResultsIcon', "download results button exists and is correctly not enabled");
-	}, null, 10000);
+  casper.waitForSelector('a.downloadResultsIcon', function () {
+    test.assertNotVisible('a.downloadResultsIcon', "download results button exists and is correctly not enabled");
+  }, null, 10000);
 
-	casper.waitForSelector('a.downloadModelsIcon', function () {
-		test.assertVisible('a.downloadModelsIcon', "download models button exists and is correctly enabled");
-	}, null, 10000);
+  casper.waitForSelector('a.downloadModelsIcon', function () {
+    test.assertVisible('a.downloadModelsIcon', "download models button exists and is correctly enabled");
+  }, null, 10000);
 
-	casper.waitForSelector('a.cloneIcon', function () {
-		test.assertDoesntExist('a.enabled.cloneIcon', "clone button exists and is correctly not enabled");
-	}, null, 10000);
+  casper.waitForSelector('a.cloneIcon', function () {
+    test.assertDoesntExist('a.enabled.cloneIcon', "clone button exists and is correctly not enabled");
+  }, null, 10000);
 }
 
-function doPostPersistenceExperimentsTableButtonCheck(test) {
-	casper.waitForSelector('button.btn.SaveButton[disabled]', function () {
-		casper.wait(5000, function () {});
-		
-		test.assertSelectorHasText('span[class*="tabber"]', 'Console', 'Experiments button exists');
+function doPostPersistenceExperimentsTableButtonCheck (test) {
+  casper.waitForSelector('button.btn.SaveButton[disabled]', function () {
+    casper.wait(5000, function () {});
+    
+    test.assertSelectorHasText('span[class*="tabber"]', 'Console', 'Experiments button exists');
 
-		casper.mouse.move('tr.experimentsTableColumn:nth-child(1)');
-		//Check presence of experiment console buttons AFTER persistence
-		casper.waitForSelector('a.activeIcon', function () {
-			test.assertNotVisible('a.activeIcon', "active button exists and is correctly not enabled");
-		}, null, 5000);
+    casper.mouse.move('tr.experimentsTableColumn:nth-child(1)');
+    // Check presence of experiment console buttons AFTER persistence
+    casper.waitForSelector('a.activeIcon', function () {
+      test.assertNotVisible('a.activeIcon', "active button exists and is correctly not enabled");
+    }, null, 5000);
 
-		casper.waitForSelector('a.downloadResultsIcon', function () {
-			test.assertNotVisible('a.downloadResultsIcon', "download results button exists and is correctly not enabled");
-		}, null, 5000);
+    casper.waitForSelector('a.downloadResultsIcon', function () {
+      test.assertNotVisible('a.downloadResultsIcon', "download results button exists and is correctly not enabled");
+    }, null, 5000);
 
-		casper.waitUntilVisible('a.downloadModelsIcon', function () {
-			test.assertVisible('a.downloadModelsIcon', "download models button exists and is correctly enabled");
-		}, null, 5000);
+    casper.waitUntilVisible('a.downloadModelsIcon', function () {
+      test.assertVisible('a.downloadModelsIcon', "download models button exists and is correctly enabled");
+    }, null, 5000);
 
-		casper.waitUntilVisible('a.cloneIcon', function () {
-			test.assertVisible('a.cloneIcon', "clone button exists and is correctly enabled");
-		}, null, 5000);
+    casper.waitUntilVisible('a.cloneIcon', function () {
+      test.assertVisible('a.cloneIcon', "clone button exists and is correctly enabled");
+    }, null, 5000);
 
-		casper.waitUntilVisible('a.deleteIcon', function () {
-			test.assertVisible('a.deleteIcon', "delete button exists and is correctly enabled");
-		}, null, 5000);
-	});
+    casper.waitUntilVisible('a.deleteIcon', function () {
+      test.assertVisible('a.deleteIcon', "delete button exists and is correctly enabled");
+    }, null, 5000);
+  });
 }
 
 
-function doSpotlightCheck(test, spotlight_search, persisted, check_recorded_or_set_parameters) {
-	// do checks only if spotlight search is specified
-	if(spotlight_search!= '') {
-		test.assertExists('i.fa-search', "Spotlight button exists")
-		casper.mouseEvent('click', 'i.fa-search', "attempting to open spotlight");
+function doSpotlightCheck (test, spotlight_search, persisted, check_recorded_or_set_parameters) {
+  // do checks only if spotlight search is specified
+  if (spotlight_search != '') {
+    test.assertExists('i.fa-search', "Spotlight button exists")
+    casper.mouseEvent('click', 'i.fa-search', "attempting to open spotlight");
 
-		casper.waitUntilVisible('div#spotlight', function () {
-			test.assertVisible('div#spotlight', "Spotlight opened");
+    casper.waitUntilVisible('div#spotlight', function () {
+      test.assertVisible('div#spotlight', "Spotlight opened");
 
-			//type in the spotlight
-			casper.sendKeys('input#typeahead', spotlight_search, {keepFocus: true});
-			//press enter
-			casper.sendKeys('input#typeahead', casper.page.event.key.Return, {keepFocus: true});
+      // type in the spotlight
+      casper.sendKeys('input#typeahead', spotlight_search, { keepFocus: true });
+      // press enter
+      casper.sendKeys('input#typeahead', casper.page.event.key.Return, { keepFocus: true });
 
-			casper.waitUntilVisible('div#spotlight', function () {
+      casper.waitUntilVisible('div#spotlight', function () {
 
-				casper.then(function () {
+        casper.then(function () {
 
-					if (persisted) {
-						if (check_recorded_or_set_parameters) {
-							this.echo("Waiting to see if the recorded variables button becomes visible");
-							casper.waitUntilVisible('button#watch', function () {
-								test.assertVisible('button#watch', "Record variables icon correctly visible");
-								this.echo("Recorded variables button became visible correctly");
-							}, null, 8000);
-						} else {
-							//TESTS THAT THE PARAMETER IS SETTABLE
-							test.assertVisible('input.spotlight-input', "Parameter input field correctly visible");
-						}
-					} else {
-						if (check_recorded_or_set_parameters) {
-							//TESTS THAT THE VARIABLE IS NOT RECORDABLE
-							test.assertNotVisible('button#watch', "Record variables icon correctly not visible");
-						} else {
-							//TESTS THAT THE PARAMETER IS NOT SETTABLE
-							test.assertNotVisible('input.spotlight-input', "Parameter input field correctly not visible");
-						}
-					}
-				});
+          if (persisted) {
+            if (check_recorded_or_set_parameters) {
+              this.echo("Waiting to see if the recorded variables button becomes visible");
+              casper.waitUntilVisible('button#watch', function () {
+                test.assertVisible('button#watch', "Record variables icon correctly visible");
+                this.echo("Recorded variables button became visible correctly");
+              }, null, 8000);
+            } else {
+              // TESTS THAT THE PARAMETER IS SETTABLE
+              test.assertVisible('input.spotlight-input', "Parameter input field correctly visible");
+            }
+          } else {
+            if (check_recorded_or_set_parameters) {
+              // TESTS THAT THE VARIABLE IS NOT RECORDABLE
+              test.assertNotVisible('button#watch', "Record variables icon correctly not visible");
+            } else {
+              // TESTS THAT THE PARAMETER IS NOT SETTABLE
+              test.assertNotVisible('input.spotlight-input', "Parameter input field correctly not visible");
+            }
+          }
+        });
 
-				casper.then(function () {
-					this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
-					casper.mouseEvent('click', 'div#spotlight', "attempting to close spotlight");
-					this.echo("Clicking to close spotlight");
-					casper.sendKeys('input#typeahead', casper.page.event.key.Escape, {keepFocus: true});
-					this.echo("Hitting escape to close spotlight");
+        casper.then(function () {
+          this.mouse.move('tr.experimentsTableColumn:nth-child(1)');
+          casper.mouseEvent('click', 'div#spotlight', "attempting to close spotlight");
+          this.echo("Clicking to close spotlight");
+          casper.sendKeys('input#typeahead', casper.page.event.key.Escape, { keepFocus: true });
+          this.echo("Hitting escape to close spotlight");
 
-					this.waitWhileVisible('div#spotlight', function () {
-						test.assertNotVisible('div#spotlight', "Spotlight closed correctly");
-					}, null, 10000);
-				})
-			});
+          this.waitWhileVisible('div#spotlight', function () {
+            test.assertNotVisible('div#spotlight', "Spotlight closed correctly");
+          }, null, 10000);
+        })
+      });
 
-		});
-	}
+    });
+  }
 }
 
-function doPrePersistenceSpotlightCheckRecordedVariables(test, spotlight_search) {
-	doSpotlightCheck(test, spotlight_search, false, true);
+function doPrePersistenceSpotlightCheckRecordedVariables (test, spotlight_search) {
+  doSpotlightCheck(test, spotlight_search, false, true);
 }
 
-function doPrePersistenceSpotlightCheckSetParameters(test, spotlight_search) {
-	doSpotlightCheck(test, spotlight_search, false, false);
+function doPrePersistenceSpotlightCheckSetParameters (test, spotlight_search) {
+  doSpotlightCheck(test, spotlight_search, false, false);
 }
 
-function doPostPersistenceSpotlightCheckRecordedVariables(test, spotlight_search) {
-	doSpotlightCheck(test, spotlight_search, true, true);
+function doPostPersistenceSpotlightCheckRecordedVariables (test, spotlight_search) {
+  doSpotlightCheck(test, spotlight_search, true, true);
 }
 
-function doPostPersistenceSpotlightCheckSetParameters(test, spotlight_search) {
-	doSpotlightCheck(test, spotlight_search, true, false);
+function doPostPersistenceSpotlightCheckSetParameters (test, spotlight_search) {
+  doSpotlightCheck(test, spotlight_search, true, false);
 }
 
-function testPersistedProjectFeatures(test,url){
-	casper.thenOpen(url, function () {
-		this.echo("Loading a model that is persisted at " + url);
+function testPersistedProjectFeatures (test,url){
+  casper.thenOpen(url, function () {
+    this.echo("Loading a model that is persisted at " + url);
 
-		casper.then(function () {
-			casper.waitWhileVisible('div[id="loading-spinner"]', function () {
-				this.echo("I've waited for "+url+" project to load.");
-				test.assertTitle("geppetto", "geppetto title is ok");
-				test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
-				test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
-				test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
-			},null,defaultLongWaitingTime);
-		});
+    casper.then(function () {
+      casper.waitWhileVisible('div[id="loading-spinner"]', function () {
+        this.echo("I've waited for " + url + " project to load.");
+        test.assertTitle("geppetto", "geppetto title is ok");
+        test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
+        test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
+        test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
+      },null,defaultLongWaitingTime);
+    });
 
-		casper.then(function () {
-			casper.then(function () {
-				var experiments = casper.evaluate(function() {return window.Project.getExperiments().length;});
-				test.assertEquals(experiments, 3, "Initial amount of experiments for hhcell checked");
-			});
+    casper.then(function () {
+      casper.then(function () {
+        var experiments = casper.evaluate(function () {
+          return window.Project.getExperiments().length;
+        });
+        test.assertEquals(experiments, 3, "Initial amount of experiments for hhcell checked");
+      });
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Project.getExperiments().length > 1;
-				},"Loaded project from persistence");
-			});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Project.getExperiments().length > 1;
+        },"Loaded project from persistence");
+      });
 
-			casper.then(function(){
-				casper.evaluate(function() {
-					window.Project.getExperiments()[1].setActive();
-				});
-			});
+      casper.then(function (){
+        casper.evaluate(function () {
+          window.Project.getExperiments()[1].setActive();
+        });
+      });
 
-			casper.then(function () {
-				casper.waitWhileVisible('div[id="loading-spinner"]', function () {
-					this.echo("I've waited for experment to be actve.");
-					test.assertEval(function() {
-						return window.Project.getActiveExperiment().getId()===2;
-					},"New Active experiment id of loaded project checked");
-				},null,10000);
-			});
+      casper.then(function () {
+        casper.waitWhileVisible('div[id="loading-spinner"]', function () {
+          this.echo("I've waited for experment to be actve.");
+          test.assertEval(function () {
+            return window.Project.getActiveExperiment().getId() === 2;
+          },"New Active experiment id of loaded project checked");
+        },null,10000);
+      });
 
-			casper.then(function () {
-				var evaluate = casper.evaluate(function() {return hhcell!=null;});
-				test.assertEquals(evaluate,true, "Top level instance present");
-			});
+      casper.then(function () {
+        var evaluate = casper.evaluate(function () {
+          return hhcell != null;
+        });
+        test.assertEquals(evaluate,true, "Top level instance present");
+      });
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2 &&
-					window.Model.getVariables()[0].getId() == 'hhcell' && window.Model.getVariables()[1].getId() == 'time';
-				},"2 top Variables as expected for hhcell");
-			});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Model.getVariables() != undefined && window.Model.getVariables().length == 2
+          && window.Model.getVariables()[0].getId() == 'hhcell' && window.Model.getVariables()[1].getId() == 'time';
+        },"2 top Variables as expected for hhcell");
+      });
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
-				},"2 Libraries as expected for hhcell");
-			});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Model.getLibraries() != undefined && window.Model.getLibraries().length == 2;
+        },"2 Libraries as expected for hhcell");
+      });
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'hhcell';
-				},"1 top level instance as expected for hhcell");
-			});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Instances != undefined && window.Instances.length == 2 && window.Instances[0].getId() == 'hhcell';
+        },"1 top level instance as expected for hhcell");
+      });
 
-		});
+    });
 
-		casper.then(function () {
-			testUpload2DropBoxFeature(test,url);
-		});
+    casper.then(function () {
+      testUpload2DropBoxFeature(test,url);
+    });
 
-		casper.then(function () {
-			testDownloadExperimentModel(test);
-		});
+    casper.then(function () {
+      testDownloadExperimentModel(test);
+    });
 
-		casper.then(function () {
-			testDownloadExperimentResults(test);
-		});
+    casper.then(function () {
+      testDownloadExperimentResults(test);
+    });
 
-		for(var testRun=0;testRun<amountOfRuns;testRun++){
-			casper.then(function () {
-				testCreateExperiment(test);
-			});
+    for (var testRun = 0;testRun < amountOfRuns;testRun++){
+      casper.then(function () {
+        testCreateExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,4);
-			});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,4);
+      });
 
-			casper.then(function () {
-				testDeleteExperiment(test);
-			});
+      casper.then(function () {
+        testDeleteExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,3);
-			});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,3);
+      });
 
-			casper.then(function () {
-				testCloneExperiment(test);
-			});
+      casper.then(function () {
+        testCloneExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,4);
-			});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,4);
+      });
 
-			casper.then(function () {
-				testDeleteExperiment(test);
-			});
+      casper.then(function () {
+        testDeleteExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,3);
-			});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,3);
+      });
 
-			casper.then(function () {
-				testCreateExperiment(test);
-			});
+      casper.then(function () {
+        testCreateExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,4);
-			});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,4);
+      });
 
-			casper.then(function () {
-				testSaveExperimentProperties(test);
-			});
+      casper.then(function () {
+        testSaveExperimentProperties(test);
+      });
 
-			casper.then(function () {
-				testSaveProjectProperties(test);
-			});
+      casper.then(function () {
+        testSaveProjectProperties(test);
+      });
 
-			casper.then(function () {
-				testDeleteExperiment(test);
-			});
+      casper.then(function () {
+        testDeleteExperiment(test);
+      });
 
-			casper.then(function () {
-				experimentConsoleToggleTests(test,3);
-			});
-		}
-	});
+      casper.then(function () {
+        experimentConsoleToggleTests(test,3);
+      });
+    }
+  });
 }
 
-function testUpload2DropBoxFeature(test,projectURL){
-	casper.then(function () {
-		permissions = test.assertEval(function() {
-			var login = GEPPETTO.UserController.isLoggedIn();
-			var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
-			var projectPersisted = window.Project.persisted;
-			return writePermission && projectPersisted && login;
-		},"No Permissions restrictions for uploading!");
-	});
+function testUpload2DropBoxFeature (test,projectURL){
+  casper.then(function () {
+    permissions = test.assertEval(function () {
+      var login = GEPPETTO.UserController.isLoggedIn();
+      var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
+      var projectPersisted = window.Project.persisted;
+      return writePermission && projectPersisted && login;
+    },"No Permissions restrictions for uploading!");
+  });
 
-	
-	casper.then(function () {
-		casper.clickLabel('Console', 'span');
-	});
+  
+  casper.then(function () {
+    casper.clickLabel('Console', 'span');
+  });
 
-	casper.then(function(){
-		this.waitUntilVisible('div[id="undefined_console"]', function () {
-			casper.then(function () {
-				casper.evaluate(function() {
-					G.debug(true);
-				});
-			});
-		});
-	});
-	
-	if(dropboxcode!=null && dropboxcode !=undefined && dropboxcode!=""){
+  casper.then(function (){
+    this.waitUntilVisible('div[id="undefined_console"]', function () {
+      casper.then(function () {
+        casper.evaluate(function () {
+          G.debug(true);
+        });
+      });
+    });
+  });
+  
+  if (dropboxcode != null && dropboxcode != undefined && dropboxcode != ""){
 
-		casper.then(function () {
-			casper.evaluate(function(dropboxcode) {
-				G.linkDropBox(dropboxcode);
-			},dropboxcode);
-			this.echo("Copy drop box access code"+dropboxcode);
-		});
+    casper.then(function () {
+      casper.evaluate(function (dropboxcode) {
+        G.linkDropBox(dropboxcode);
+      },dropboxcode);
+      this.echo("Copy drop box access code" + dropboxcode);
+    });
 
-		casper.then(function () {
-			casper.waitForText("Dropbox linked successfully", function() {
-				this.echo('Dropbox linked successfully using persisted project hhcell');
-			},10000);
-		});
+    casper.then(function () {
+      casper.waitForText("Dropbox linked successfully", function () {
+        this.echo('Dropbox linked successfully using persisted project hhcell');
+      },10000);
+    });
 
-		casper.then(function () {
-			casper.evaluate(function(permissions) {
-				if(permissions){
-					window.Project.getActiveExperiment().uploadModel('hhcell');
-					window.Project.getActiveExperiment().uploadResults("hhcell", "GEPPETTO_RECORDING");
-				}
-			},permissions);
-			this.echo("");
-		});
+    casper.then(function () {
+      casper.evaluate(function (permissions) {
+        if (permissions){
+          window.Project.getActiveExperiment().uploadModel('hhcell');
+          window.Project.getActiveExperiment().uploadResults("hhcell", "GEPPETTO_RECORDING");
+        }
+      },permissions);
+      this.echo("");
+    });
 
-		casper.then(function () {
-			casper.waitForText("Results uploaded succesfully", function() {
-				this.echo('Results uploaded succesfully using persisted project hhcell');
-			},150000);
+    casper.then(function () {
+      casper.waitForText("Results uploaded succesfully", function () {
+        this.echo('Results uploaded succesfully using persisted project hhcell');
+      },150000);
 
-			casper.waitForText("Model uploaded succesfully", function() {
-				this.echo('Model uploaded succesfully using persisted project hhcell');
-			},150000);
-		});
-	}
+      casper.waitForText("Model uploaded succesfully", function () {
+        this.echo('Model uploaded succesfully using persisted project hhcell');
+      },150000);
+    });
+  }
 }
 
-function testDownloadExperimentModel(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			var login = GEPPETTO.UserController.isLoggedIn();
-			var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
-			var projectPersisted = window.Project.persisted;
-			if(writePermission && projectPersisted && login){
-				window.Project.downloadModel('hhcell');
-			}
-		});
-	});
+function testDownloadExperimentModel (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      var login = GEPPETTO.UserController.isLoggedIn();
+      var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
+      var projectPersisted = window.Project.persisted;
+      if (writePermission && projectPersisted && login){
+        window.Project.downloadModel('hhcell');
+      }
+    });
+  });
 
-	casper.then(function () {
-		casper.waitForText("Results downloaded succesfully", function() {
-			this.echo('Results downloaded succesfully using persisted project hhcell');
-		},150000);
-	});
+  casper.then(function () {
+    casper.waitForText("Results downloaded succesfully", function () {
+      this.echo('Results downloaded succesfully using persisted project hhcell');
+    },150000);
+  });
 }
 
-function testDownloadExperimentResults(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			var login = GEPPETTO.UserController.isLoggedIn();
-			var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
-			var projectPersisted = window.Project.persisted;
-			if(writePermission && projectPersisted && login){
-				window.Project.getActiveExperiment().downloadResults('hhcell', 'GEPPETTO_RECORDING');
-			}
-		});
-	});
+function testDownloadExperimentResults (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      var login = GEPPETTO.UserController.isLoggedIn();
+      var writePermission = GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT);
+      var projectPersisted = window.Project.persisted;
+      if (writePermission && projectPersisted && login){
+        window.Project.getActiveExperiment().downloadResults('hhcell', 'GEPPETTO_RECORDING');
+      }
+    });
+  });
 
-	casper.then(function () {
-		casper.waitForText("Results downloaded succesfully", function() {
-			this.echo('Results downloaded succesfully using persisted project hhcell');
-		},150000);
-	});
+  casper.then(function () {
+    casper.waitForText("Results downloaded succesfully", function () {
+      this.echo('Results downloaded succesfully using persisted project hhcell');
+    },150000);
+  });
 }
 
-function testSaveProjectProperties(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			var properties = {"name": "New Project Name"};
-			window.Project.saveProjectProperties(properties);
-		});
-		this.echo("--------Save project using persisted project hhcell");
-	});
+function testSaveProjectProperties (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      var properties = { "name": "New Project Name" };
+      window.Project.saveProjectProperties(properties);
+    });
+    this.echo("--------Save project using persisted project hhcell");
+  });
 
-	casper.then(function () {
-		casper.waitForText("Project saved succesfully", function() {
-			this.echo('Project saved succesfullyusing persisted project hhcell');
-		},150000);
-	});
+  casper.then(function () {
+    casper.waitForText("Project saved succesfully", function () {
+      this.echo('Project saved succesfullyusing persisted project hhcell');
+    },150000);
+  });
 }
 
-function testSaveExperimentProperties(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			var properties = {"name": "New Name for Experiment",
-					"conversionServiceId" : "testService",
-					"simulatorId" : "testSimulator",
-					"length" : "2",
-					"timeStep" : "3",
-					"aspectInstancePath" : "hhcell(net1)"};
-			window.Project.getExperiments()[(window.Project.getExperiments().length-1)].saveExperimentProperties(properties);
-		});
-		this.echo("--------Save experiment using persisted project hhcell");
-	});
+function testSaveExperimentProperties (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      var properties = { 
+        "name": "New Name for Experiment",
+        "conversionServiceId" : "testService",
+        "simulatorId" : "testSimulator",
+        "length" : "2",
+        "timeStep" : "3",
+        "aspectInstancePath" : "hhcell(net1)" 
+      };
+      window.Project.getExperiments()[(window.Project.getExperiments().length - 1)].saveExperimentProperties(properties);
+    });
+    this.echo("--------Save experiment using persisted project hhcell");
+  });
 
-	casper.then(function () {
-		casper.waitForText("Experiment saved succesfully", function() {
-			this.echo('Experiment saved succesfully using persisted project hhcell');
-		},150000);
-	});
+  casper.then(function () {
+    casper.waitForText("Experiment saved succesfully", function () {
+      this.echo('Experiment saved succesfully using persisted project hhcell');
+    },150000);
+  });
 }
 
-function testDeleteExperiment(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			window.Project.getExperiments()[(window.Project.getExperiments().length-1)].deleteExperiment();
-		});
-		this.echo("--------Deleting new experiment using persisted project hhcell");
-	});
+function testDeleteExperiment (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      window.Project.getExperiments()[(window.Project.getExperiments().length - 1)].deleteExperiment();
+    });
+    this.echo("--------Deleting new experiment using persisted project hhcell");
+  });
 
-	casper.then(function () {
-		casper.waitForText("Experiment deleted succesfully", function() {
-			this.echo('Experiment deleted succesfully using persisted project hhcell');
+  casper.then(function () {
+    casper.waitForText("Experiment deleted succesfully", function () {
+      this.echo('Experiment deleted succesfully using persisted project hhcell');
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Project.getExperiments().length===3;
-				},"Experiment deleted checked using persisted project hhcell");
-			});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Project.getExperiments().length === 3;
+        },"Experiment deleted checked using persisted project hhcell");
+      });
 
-			casper.then(function() {    
-				casper.evaluate(function() {
-					document.getElementById('infomodal-btn').click();
-				});
-			});
-		},150000);
-	});
+      casper.then(function () {    
+        casper.evaluate(function () {
+          document.getElementById('infomodal-btn').click();
+        });
+      });
+    },150000);
+  });
 }
 
-function testCreateExperiment(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			window.Project.newExperiment();
-		});
-		this.echo("------Creating new experiment using persisted project hhcell");
-	});
+function testCreateExperiment (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      window.Project.newExperiment();
+    });
+    this.echo("------Creating new experiment using persisted project hhcell");
+  });
 
-	casper.then(function () {
-		casper.waitForText("Experiment created succesfully", function() {
-			this.echo("Experiment created succesfully using persisted project hhcell");
+  casper.then(function () {
+    casper.waitForText("Experiment created succesfully", function () {
+      this.echo("Experiment created succesfully using persisted project hhcell");
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Project.getExperiments().length===4;
-				},"New experiment created checked using persisted project hhcell");
-			});
-		},150000);
-	});
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Project.getExperiments().length === 4;
+        },"New experiment created checked using persisted project hhcell");
+      });
+    },150000);
+  });
 }
 
-function testCloneExperiment(test){
-	casper.then(function () {
-		casper.evaluate(function() {
-			window.Project.getExperiments()[0].clone();
-		});
-		this.echo("-----Cloning new experiment using persisted project hhcell");
-	});
+function testCloneExperiment (test){
+  casper.then(function () {
+    casper.evaluate(function () {
+      window.Project.getExperiments()[0].clone();
+    });
+    this.echo("-----Cloning new experiment using persisted project hhcell");
+  });
 
-	casper.then(function () {
-		casper.waitForText("Experiment created succesfully", function() {
-			this.echo('Experiment cloned succesfully using persisted project hhcell');
+  casper.then(function () {
+    casper.waitForText("Experiment created succesfully", function () {
+      this.echo('Experiment cloned succesfully using persisted project hhcell');
 
-			casper.then(function () {
-				test.assertEval(function() {
-					return window.Project.getExperiments().length===4;
-				},"Experiment cloned checked using persisted project hhcell");
+      casper.then(function () {
+        test.assertEval(function () {
+          return window.Project.getExperiments().length === 4;
+        },"Experiment cloned checked using persisted project hhcell");
 
-				test.assertEval(function() {
-					return Project.getExperiments()[0].simulatorConfigurations["hhcell"].length ===
-						Project.getExperiments()[Project.getExperiments().length-1].simulatorConfigurations["hhcell"].length;
-				},"Clone Experiment - Simulator Configuration duration checked");
+        test.assertEval(function () {
+          return Project.getExperiments()[0].simulatorConfigurations["hhcell"].length
+            === Project.getExperiments()[Project.getExperiments().length - 1].simulatorConfigurations["hhcell"].length;
+        },"Clone Experiment - Simulator Configuration duration checked");
 
-				test.assertEval(function() {
-					return Project.getExperiments()[0].simulatorConfigurations["hhcell"].timeStep===
-						Project.getExperiments()[Project.getExperiments().length-1].simulatorConfigurations["hhcell"].timeStep;
-				},"Clone Experiment - Simulator Configuration time step checked");
+        test.assertEval(function () {
+          return Project.getExperiments()[0].simulatorConfigurations["hhcell"].timeStep
+            === Project.getExperiments()[Project.getExperiments().length - 1].simulatorConfigurations["hhcell"].timeStep;
+        },"Clone Experiment - Simulator Configuration time step checked");
 
-				test.assertEval(function() {
-					return Project.getExperiments()[0].simulatorConfigurations["hhcell"].simulatorId===
-						Project.getExperiments()[Project.getExperiments().length-1].simulatorConfigurations["hhcell"].simulatorId;
-				},"Clone Experiment - Simulator Configuration service id checked");
-			});
-		},150000);
-	});
+        test.assertEval(function () {
+          return Project.getExperiments()[0].simulatorConfigurations["hhcell"].simulatorId
+            === Project.getExperiments()[Project.getExperiments().length - 1].simulatorConfigurations["hhcell"].simulatorId;
+        },"Clone Experiment - Simulator Configuration service id checked");
+      });
+    },150000);
+  });
 }
 
-function experimentConsoleToggleTests(test,rowLength){
-	casper.then(function () {
-		casper.then(function () {
-			this.wait(1500, function () {});
-		});
+function experimentConsoleToggleTests (test,rowLength){
+  casper.then(function () {
+    casper.then(function () {
+      this.wait(1500, function () {});
+    });
 
-		casper.then(function () {
-			this.echo("Opening experiment console");
-			casper.clickLabel('Experiments', 'span');
+    casper.then(function () {
+      this.echo("Opening experiment console");
+      casper.clickLabel('Experiments', 'span');
 
-			this.waitUntilVisible('div#experimentsOutput', function () {
-				test.assertVisible('div#experimentsOutput', "The experiment panel is correctly open.");
-			}, null, 15000);
-		});
-		casper.then(function () {
-			var length = casper.evaluate(function() {
-				return document.getElementsByClassName("nested-experiment-info").length;
-			});
+      this.waitUntilVisible('div#experimentsOutput', function () {
+        test.assertVisible('div#experimentsOutput', "The experiment panel is correctly open.");
+      }, null, 15000);
+    });
+    casper.then(function () {
+      var length = casper.evaluate(function () {
+        return document.getElementsByClassName("nested-experiment-info").length;
+      });
 
-			test.assertEquals(length, rowLength,"Amount of experiment rows correct")
-		});
+      test.assertEquals(length, rowLength,"Amount of experiment rows correct")
+    });
 
-		casper.then(function () {
-			casper.then(function () {
-				casper.clickLabel('Console', 'span');
-			});
+    casper.then(function () {
+      casper.then(function () {
+        casper.clickLabel('Console', 'span');
+      });
 
-			casper.then(function(){
-				this.waitUntilVisible('div[id="undefined_console"]', function () {
-					casper.then(function () {
-						casper.evaluate(function() {
-							G.debug(true);
-							GEPPETTO.CommandController.clear();
-						});
-					});
-				});
-			});
-		});
-	});
+      casper.then(function (){
+        this.waitUntilVisible('div[id="undefined_console"]', function () {
+          casper.then(function () {
+            casper.evaluate(function () {
+              G.debug(true);
+              GEPPETTO.CommandController.clear();
+            });
+          });
+        });
+      });
+    });
+  });
 }

--- a/tests/casperjs/UIComponentsTests.js
+++ b/tests/casperjs/UIComponentsTests.js
@@ -1,506 +1,534 @@
 var collapsedWidgetHeight = 35;
-casper.test.begin('Geppetto basic UI Components/Widgets Tests', function suite(test) {
-	casper.options.viewportSize = {
-			width: 1340,
-			height: 768
-	};
+casper.test.begin('Geppetto basic UI Components/Widgets Tests', function suite (test) {
+  casper.options.viewportSize = {
+    width: 1340,
+    height: 768
+  };
 
-	casper.on("page.error", function(msg, trace) {
-		this.echo("Error: " + msg, "ERROR");
-	});
+  casper.on("page.error", function (msg, trace) {
+    this.echo("Error: " + msg, "ERROR");
+  });
 
-	// show page level errors
-	casper.on('resource.received', function (resource) {
-		var status = resource.status;
-		if (status >= 400) {
-			this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
-		}
-	});
+  // show page level errors
+  casper.on('resource.received', function (resource) {
+    var status = resource.status;
+    if (status >= 400) {
+      this.echo('URL: ' + resource.url + ' Status: ' + resource.status);
+    }
+  });
 
-	casper.start(urlBase+"org.geppetto.frontend", function () {
-		this.echo(urlBase+baseFollowUp+hhcellProject);
-		this.waitForSelector('div[project-id="1"]', function () {
-			this.echo("I've waited for the projects to load.");
-			test.assertExists('div#logo', "logo is found");
-			test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
-			test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
-			test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
-			test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
-			test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
-			test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
-			test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
-			test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
-			test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
-			test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
-		}, null, 3000);
-	});
+  casper.start(urlBase + "org.geppetto.frontend", function () {
+    this.echo(urlBase + baseFollowUp + hhcellProject);
+    this.waitForSelector('div[project-id="1"]', function () {
+      this.echo("I've waited for the projects to load.");
+      test.assertExists('div#logo', "logo is found");
+      test.assertExists('div[project-id="1"]', "Project width id 1 from core bundle are present");
+      test.assertExists('div[project-id="3"]', "Project width id 3 from core bundle are present");
+      test.assertExists('div[project-id="4"]', "Project width id 4 from core bundle are present");
+      test.assertExists('div[project-id="5"]', "Project width id 5 from core bundle are present");
+      test.assertExists('div[project-id="6"]', "Project width id 6 from core bundle are present");
+      test.assertExists('div[project-id="8"]', "Project width id 8 from core bundle are present");
+      test.assertExists('div[project-id="9"]', "Project width id 9 from core bundle are present");
+      test.assertExists('div[project-id="16"]', "Project width id 16 from core bundle are present");
+      test.assertExists('div[project-id="18"]', "Project width id 18 from core bundle are present");
+      test.assertExists('div[project-id="58"]', "Project width id 58 from core bundle are present");
+    }, null, 3000);
+  });
 
-	/**Tests Widgets, components and other UI elements using a new project with no scene loaded**/
-	casper.thenOpen(urlBase+baseFollowUp,function() {
-		casper.then(function(){launchTest(test,"Default Empty Project",5000);});
-		casper.then(function(){casper.wait(2000, function () {
-			//FIXME: Broken after tabbed drawer refactoring, on the to do list.
-			casper.then(function(){consoleTest(test);});
-			casper.then(function(){debugModeTest(test);});
-			casper.then(function(){helpWindowTest(test);});
-			casper.then(function(){popupWidgetTest(test);});
-			casper.then(function(){plotWidgetTest(test);});
-			casper.then(function(){treeVisualizerTest(test);});
-			casper.then(function(){variableVisualizerTest(test);});
-			casper.then(function(){unitsControllerTest(test);});
-		})});
-	});
+  /** Tests Widgets, components and other UI elements using a new project with no scene loaded**/
+  casper.thenOpen(urlBase + baseFollowUp,function () {
+    casper.then(function (){
+      launchTest(test,"Default Empty Project",5000);
+    });
+    casper.then(function (){
+      casper.wait(2000, function () {
+      // FIXME: Broken after tabbed drawer refactoring, on the to do list.
+        casper.then(function (){
+          consoleTest(test);
+        });
+        casper.then(function (){
+          debugModeTest(test);
+        });
+        casper.then(function (){
+          helpWindowTest(test);
+        });
+        casper.then(function (){
+          popupWidgetTest(test);
+        });
+        casper.then(function (){
+          plotWidgetTest(test);
+        });
+        casper.then(function (){
+          treeVisualizerTest(test);
+        });
+        casper.then(function (){
+          variableVisualizerTest(test);
+        });
+        casper.then(function (){
+          unitsControllerTest(test);
+        });
+      })
+    });
+  });
 
-	casper.run(function() {
-		test.done();
-	});
+  casper.run(function () {
+    test.done();
+  });
 });
 
-/* Tests debug mode functionality
+/*
+ * Tests debug mode functionality
  */
-function debugModeTest(test){
-	//test debug mode is off by default
-	casper.then(function(){
-		var debugMode = casper.evaluate(function() {
-			return G.isDebugOn();
-		});
-		test.assertEquals(debugMode, false, "Debug mode correctly disabled.");
-	});
+function debugModeTest (test){
+  // test debug mode is off by default
+  casper.then(function (){
+    var debugMode = casper.evaluate(function () {
+      return G.isDebugOn();
+    });
+    test.assertEquals(debugMode, false, "Debug mode correctly disabled.");
+  });
 
-	//test debug mode can be turn on
-	casper.then(function(){
-		var debugMode = casper.evaluate(function() {
-			G.debug(true);
-			return G.isDebugOn();
-		});
-		test.assertEquals(debugMode, true, "Debug mode correctly enabled.");
-	});
+  // test debug mode can be turn on
+  casper.then(function (){
+    var debugMode = casper.evaluate(function () {
+      G.debug(true);
+      return G.isDebugOn();
+    });
+    test.assertEquals(debugMode, true, "Debug mode correctly enabled.");
+  });
 
-	//tests that debug mode can be turn off
-	casper.then(function(){
-		var debugMode = casper.evaluate(function() {
-			G.debug(false);
-			return G.isDebugOn();
-		});
-		test.assertEquals(debugMode, false, "Debug mode correctly disabled.");
-	});
+  // tests that debug mode can be turn off
+  casper.then(function (){
+    var debugMode = casper.evaluate(function () {
+      G.debug(false);
+      return G.isDebugOn();
+    });
+    test.assertEquals(debugMode, false, "Debug mode correctly disabled.");
+  });
 }
 
-/* Tests help window
+/*
+ * Tests help window
  */
-function helpWindowTest(test){
-	//open help window
-	casper.then(function () {
-		buttonClick("#genericHelpBtn");
-	});
+function helpWindowTest (test){
+  // open help window
+  casper.then(function () {
+    buttonClick("#genericHelpBtn");
+  });
 
-	casper.then(function(){
-		//wait for help modal to open and test elements are present
-		this.waitUntilVisible('div[id="help-modal"]', function () {
-			//tests help window has right amount of H4 headers
-			casper.then(function(){
-				var h4Elements = casper.evaluate(function() {
-					var h4Elements = $("#help-modal").find("h4").length;
-					return h4Elements;
-				});
-				test.assertEquals(h4Elements, 7, "Right amount of title headers for tutorial window");
-			});
-			//tests that help modal window has right amount of status circles
-			casper.then(function(){
-				var statusCirclesElements = casper.evaluate(function() {
-					var statusCirclesElements = $("#help-modal").find("div").find(".circle").length;
-					return statusCirclesElements;
-				});
-				test.assertEquals(statusCirclesElements, 10, "Right amount of status circles for tutorial window");
-			});
-		});
-	});
+  casper.then(function (){
+    // wait for help modal to open and test elements are present
+    this.waitUntilVisible('div[id="help-modal"]', function () {
+      // tests help window has right amount of H4 headers
+      casper.then(function (){
+        var h4Elements = casper.evaluate(function () {
+          var h4Elements = $("#help-modal").find("h4").length;
+          return h4Elements;
+        });
+        test.assertEquals(h4Elements, 7, "Right amount of title headers for tutorial window");
+      });
+      // tests that help modal window has right amount of status circles
+      casper.then(function (){
+        var statusCirclesElements = casper.evaluate(function () {
+          var statusCirclesElements = $("#help-modal").find("div").find(".circle").length;
+          return statusCirclesElements;
+        });
+        test.assertEquals(statusCirclesElements, 10, "Right amount of status circles for tutorial window");
+      });
+    });
+  });
 
-	//tests help command doesn't return null
-	casper.then(function () {
-		var helpCommand = casper.evaluate(function() {
-			return G.help();
-		});
-		test.assertNotEquals(helpCommand, null, "G.help command not null.");
-	});
+  // tests help command doesn't return null
+  casper.then(function () {
+    var helpCommand = casper.evaluate(function () {
+      return G.help();
+    });
+    test.assertNotEquals(helpCommand, null, "G.help command not null.");
+  });
 
-	//tests help modal window can be closed
-	casper.then(function () {
-		casper.evaluate(function() {
-			$("#help-modal").find("button")[0].click();
-		});
-		casper.waitWhileVisible('div[id="help-modal"]', function () {
-			this.echo("I've waited for help window to go away.");
-		});
-	});
+  // tests help modal window can be closed
+  casper.then(function () {
+    casper.evaluate(function () {
+      $("#help-modal").find("button")[0].click();
+    });
+    casper.waitWhileVisible('div[id="help-modal"]', function () {
+      this.echo("I've waited for help window to go away.");
+    });
+  });
 }
 
-/* Tests console component
+/*
+ * Tests console component
  */
-function consoleTest(test){
-	//open the console
-	casper.then(function () {
-		//buttonClick("#consoleButton");
-		casper.clickLabel('Console', 'span');
-	});
+function consoleTest (test){
+  // open the console
+  casper.then(function () {
+    // buttonClick("#consoleButton");
+    casper.clickLabel('Console', 'span');
+  });
 
-	casper.then(function () {
-		test.assertVisible('div[class*="consoleContainer"]', "The console panel is correctly visible.");
+  casper.then(function () {
+    test.assertVisible('div[class*="consoleContainer"]', "The console panel is correctly visible.");
 
-		buttonClick(".minIcons");
-		test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly hidden.");
+    buttonClick(".minIcons");
+    test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly hidden.");
 
-		casper.clickLabel('Console', 'span');
-		test.assertVisible('div[class*="consoleContainer"]', "The console panel is correctly visible.");
+    casper.clickLabel('Console', 'span');
+    test.assertVisible('div[class*="consoleContainer"]', "The console panel is correctly visible.");
 
-		buttonClick(".maxIcons");
-		var tabberHeight = casper.evaluate(function () {
-			return $(".drawer,.react-draggable").height() > 250;
-		});
-		test.assertEquals(tabberHeight, true, "Console is maximized correctly");
+    buttonClick(".maxIcons");
+    var tabberHeight = casper.evaluate(function () {
+      return $(".drawer,.react-draggable").height() > 250;
+    });
+    test.assertEquals(tabberHeight, true, "Console is maximized correctly");
 
-		buttonClick(".closeIcons");
-		test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly hidden.");
+    buttonClick(".closeIcons");
+    test.assertNotVisible('div[class*="consoleContainer"]', "The console panel is correctly hidden.");
 
-		casper.clickLabel('Console', 'span');
-	});
+    casper.clickLabel('Console', 'span');
+  });
 
-	casper.then(function(){
-		this.waitUntilVisible("#commandInputArea", function () {
-			//test console is empty upon opening
-			casper.then(function () {
-				var spanCount = casper.evaluate(function() {
-					return $("#Console1_console").find("span").length <=1;
-				});
-				test.assertEquals(spanCount, true, "Console output empty");
-			});
+  casper.then(function (){
+    this.waitUntilVisible("#commandInputArea", function () {
+      // test console is empty upon opening
+      casper.then(function () {
+        var spanCount = casper.evaluate(function () {
+          return $("#Console1_console").find("span").length <= 1;
+        });
+        test.assertEquals(spanCount, true, "Console output empty");
+      });
 
-			casper.then(function () {
-				casper.evaluate(function() {
-					G.debug(true);
-				});
-			});
+      casper.then(function () {
+        casper.evaluate(function () {
+          G.debug(true);
+        });
+      });
 
-			//dummy UI interaction to create logs on console
-			casper.then(function () {
-				buttonClick("#panHomeBtn");
-			});
+      // dummy UI interaction to create logs on console
+      casper.then(function () {
+        buttonClick("#panHomeBtn");
+      });
 
-			//test console is empty upon opening
-			casper.then(function () {
-				var spanCount = casper.evaluate(function() {
-					return $("#undefined_console").find("span").length <=4;
-				});
-				test.assertEquals(spanCount, true, "Console output not empty");
-			});
+      // test console is empty upon opening
+      casper.then(function () {
+        var spanCount = casper.evaluate(function () {
+          return $("#undefined_console").find("span").length <= 4;
+        });
+        test.assertEquals(spanCount, true, "Console output not empty");
+      });
 
-			//test clear command works on console
-			casper.then(function () {
-				var clearConsole = casper.evaluate(function() {
-					return G.clear();
-				});
-				test.assertEquals(clearConsole, "Console history cleared", "G.clear command not null.");
-			});
+      // test clear command works on console
+      casper.then(function () {
+        var clearConsole = casper.evaluate(function () {
+          return G.clear();
+        });
+        test.assertEquals(clearConsole, "Console history cleared", "G.clear command not null.");
+      });
 
-			//test console is empty after it got cleared
-			casper.then(function () {
-				var spanCount = casper.evaluate(function() {
-					return $("#undefined_console").find("span").length;
-				});
-				test.assertEquals(spanCount, 0, "Console output not empty after G.clear");
-			});
+      // test console is empty after it got cleared
+      casper.then(function () {
+        var spanCount = casper.evaluate(function () {
+          return $("#undefined_console").find("span").length;
+        });
+        test.assertEquals(spanCount, 0, "Console output not empty after G.clear");
+      });
 
-			//disable debug mode now that we are done
-			casper.then(function () {
-				casper.evaluate(function() {
-					G.debug(false);
-				});
-			});
-		});
-	});
+      // disable debug mode now that we are done
+      casper.then(function () {
+        casper.evaluate(function () {
+          G.debug(false);
+        });
+      });
+    });
+  });
 
 
-	casper.then(function () {
-		//test hiding the console
-		casper.then(function () {
-			//buttonClick("#consoleButton");
-			casper.clickLabel('Console', 'span');
-		});
-		casper.waitWhileVisible('#commandInputArea', function () {
-			this.echo("I've waited for console hide.");
-		});
-	});
+  casper.then(function () {
+    // test hiding the console
+    casper.then(function () {
+      // buttonClick("#consoleButton");
+      casper.clickLabel('Console', 'span');
+    });
+    casper.waitWhileVisible('#commandInputArea', function () {
+      this.echo("I've waited for console hide.");
+    });
+  });
 }
 
-/* Tests popup widget basic functionality:
+/*
+ * Tests popup widget basic functionality:
  * that it gets created, destroy and changes position/size.
  */
-function popupWidgetTest(test){
-	testWidget(test, 1, "Popup1",490, 394);
+function popupWidgetTest (test){
+  testWidget(test, 1, "Popup1",490, 394);
 }
 
-/* Tests popup widget basic functionality:
+/*
+ * Tests popup widget basic functionality:
  * that it gets created, destroy and changes position/size.
  */
-function plotWidgetTest(test){
-	testWidget(test, 0, "Plot1", 350, 300);
+function plotWidgetTest (test){
+  testWidget(test, 0, "Plot1", 350, 300);
 }
 
-/* Tests tree visualizer widget basic functionality:
+/*
+ * Tests tree visualizer widget basic functionality:
  * that it gets created, destroy and changes position/size.
  */
-function treeVisualizerTest(test){
-	testWidget(test, 3, "TreeVisualiserDAT1", 350, 260);
+function treeVisualizerTest (test){
+  testWidget(test, 3, "TreeVisualiserDAT1", 350, 260);
 }
 
-/* Tests variable visualizer widget basic functionality:
+/*
+ * Tests variable visualizer widget basic functionality:
  * that it gets created, destroy and changes position/size.
  */
-function variableVisualizerTest(test){
-	testWidget(test, 5, "VarVis1", 350, 120);
+function variableVisualizerTest (test){
+  testWidget(test, 5, "VarVis1", 350, 120);
 }
 
-/* Tests units controller functionality.
+/*
+ * Tests units controller functionality.
  */
-function unitsControllerTest(test){
-	//create Plot widget for testing units
-	casper.evaluate(function(){
-		G.addWidget(0);
-	});
+function unitsControllerTest (test){
+  // create Plot widget for testing units
+  casper.evaluate(function (){
+    G.addWidget(0);
+  });
 
-	casper.then(function(){
-		this.waitUntilVisible('div[id="Plot1"]', function () {
-			//test unit label without defining external unit, this will test against Math.js values
-			casper.then(function () {
-				var initialPlotLabel = casper.evaluate(function() {
-					return Plot1.getUnitLabel("S / m2");
-				});
-				test.assertEquals(initialPlotLabel, "Electric conductance over surface (S / m<sup>2</sup>)", "Test Plot1 Math.js 'S / m2' unit");
-			});
+  casper.then(function (){
+    this.waitUntilVisible('div[id="Plot1"]', function () {
+      // test unit label without defining external unit, this will test against Math.js values
+      casper.then(function () {
+        var initialPlotLabel = casper.evaluate(function () {
+          return Plot1.getUnitLabel("S / m2");
+        });
+        test.assertEquals(initialPlotLabel, "Electric conductance over surface (S / m<sup>2</sup>)", "Test Plot1 Math.js 'S / m2' unit");
+      });
 
-			//test unit after defining external unit
-			casper.then(function () {
-				var initialPlotLabel = casper.evaluate(function() {
-					GEPPETTO.UnitsController.addUnit("S/m2","Electric conductance OVER density");
-					return Plot1.getUnitLabel("S / m2");
-				});
-				test.assertEquals(initialPlotLabel, "Electric conductance over density (S / m<sup>2</sup>)", "Test Plot1 External 'S / m2' unit");
-			});
+      // test unit after defining external unit
+      casper.then(function () {
+        var initialPlotLabel = casper.evaluate(function () {
+          GEPPETTO.UnitsController.addUnit("S/m2","Electric conductance OVER density");
+          return Plot1.getUnitLabel("S / m2");
+        });
+        test.assertEquals(initialPlotLabel, "Electric conductance over density (S / m<sup>2</sup>)", "Test Plot1 External 'S / m2' unit");
+      });
 
-			//test unit after defining external unit
-			casper.then(function () {
-				var initialPlotLabel = casper.evaluate(function() {
-					return Plot1.getUnitLabel("S/m2");
-				});
-				test.assertEquals(initialPlotLabel, "Electric conductance over density (S/m<sup>2</sup>)", "Test Plot1 Math.js 'S / m2' unit");
-			});
+      // test unit after defining external unit
+      casper.then(function () {
+        var initialPlotLabel = casper.evaluate(function () {
+          return Plot1.getUnitLabel("S/m2");
+        });
+        test.assertEquals(initialPlotLabel, "Electric conductance over density (S/m<sup>2</sup>)", "Test Plot1 Math.js 'S / m2' unit");
+      });
 
-			casper.then(function () {
-				closeWidget(test, "Plot1");
-			});
-		});
-	});
+      casper.then(function () {
+        closeWidget(test, "Plot1");
+      });
+    });
+  });
 }
 
-function testWidget(test, widgetType, widgetIdentifier, originalWidth, originalHeight){
-	//call to created desired widget
-	casper.evaluate(function(widgetType){
-		G.addWidget(widgetType);
-	},widgetType);
+function testWidget (test, widgetType, widgetIdentifier, originalWidth, originalHeight){
+  // call to created desired widget
+  casper.evaluate(function (widgetType){
+    G.addWidget(widgetType);
+  },widgetType);
 
-	//test widget UI features
-	casper.then(function(){
-		this.waitUntilVisible('div[id="'+widgetIdentifier+'"]', function () {
-			//test widget got created with correct size/dimensions
-			casper.then(function () {
-				var popupSize = casper.evaluate(function(widgetIdentifier) {
-					var widget = eval(widgetIdentifier);
-					return widget.getSize();
-				},widgetIdentifier);
+  // test widget UI features
+  casper.then(function (){
+    this.waitUntilVisible('div[id="' + widgetIdentifier + '"]', function () {
+      // test widget got created with correct size/dimensions
+      casper.then(function () {
+        var popupSize = casper.evaluate(function (widgetIdentifier) {
+          var widget = eval(widgetIdentifier);
+          return widget.getSize();
+        },widgetIdentifier);
 
-				test.assertEquals(popupSize.width, originalWidth, widgetIdentifier+" initial width correct");
-				test.assertEquals(popupSize.height, originalHeight,widgetIdentifier+ " initial height correct");
-			});
+        test.assertEquals(popupSize.width, originalWidth, widgetIdentifier + " initial width correct");
+        test.assertEquals(popupSize.height, originalHeight,widgetIdentifier + " initial height correct");
+      });
 
-			casper.then(function () {
-				testMaximizeWidget(test, widgetIdentifier,originalWidth, originalHeight);
-			});
+      casper.then(function () {
+        testMaximizeWidget(test, widgetIdentifier,originalWidth, originalHeight);
+      });
 
-			casper.then(function () {
-				testMinimizeWidget(test, widgetIdentifier);		
-			});
+      casper.then(function () {
+        testMinimizeWidget(test, widgetIdentifier);
+      });
 
-			casper.then(function () {
-				testCollapseWidget(test, widgetIdentifier);		
-			});
+      casper.then(function () {
+        testCollapseWidget(test, widgetIdentifier);
+      });
 
-			casper.then(function () {
-				closeWidget(test, widgetIdentifier);
-			});
-		});
-	});
+      casper.then(function () {
+        closeWidget(test, widgetIdentifier);
+      });
+    });
+  });
 }
 
-function testMaximizeWidget(test, widgetIdentifier,originalWidth, originalHeight){
-	//maximize widget
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[2].click()
-		},widgetIdentifier);
-	});
+function testMaximizeWidget (test, widgetIdentifier,originalWidth, originalHeight){
+  // maximize widget
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[2].click()
+    },widgetIdentifier);
+  });
 
-	//test widget got maximixed by testing its size
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var popupHeight = casper.evaluate(function(widgetIdentifier) {
-				var widget = eval(widgetIdentifier);
-				return widget.$el.parent().height();
-			},widgetIdentifier);
+  // test widget got maximixed by testing its size
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var popupHeight = casper.evaluate(function (widgetIdentifier) {
+        var widget = eval(widgetIdentifier);
+        return widget.$el.parent().height();
+      },widgetIdentifier);
 
-			var expectedHeight = casper.evaluate(function(widgetIdentifier) {
-				return $(window).height()-5.2;
-			},widgetIdentifier);
+      var expectedHeight = casper.evaluate(function (widgetIdentifier) {
+        return $(window).height() - 5.2;
+      },widgetIdentifier);
 
-			var popupWidth = casper.evaluate(function(widgetIdentifier) {
-				var widget = eval(widgetIdentifier);
-				return widget.$el.parent().width();
-			},widgetIdentifier);
+      var popupWidth = casper.evaluate(function (widgetIdentifier) {
+        var widget = eval(widgetIdentifier);
+        return widget.$el.parent().width();
+      },widgetIdentifier);
 
-			var expectedWidth = casper.evaluate(function(widgetIdentifier) {
-				return $(window).width()-0.2;
-			},widgetIdentifier);
+      var expectedWidth = casper.evaluate(function (widgetIdentifier) {
+        return $(window).width() - 0.2;
+      },widgetIdentifier);
 
-			test.assertEquals(popupWidth, expectedWidth, widgetIdentifier+" maximize width correct");
-			test.assertEquals(popupHeight, expectedHeight, widgetIdentifier+" maximize height correct"); 
-		});		
-	});
+      test.assertEquals(popupWidth, expectedWidth, widgetIdentifier + " maximize width correct");
+      test.assertEquals(popupHeight, expectedHeight, widgetIdentifier + " maximize height correct"); 
+    });
+  });
 
-	//test restoring widget after it got maximized
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[2].click()
-		},widgetIdentifier);
+  // test restoring widget after it got maximized
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[2].click()
+    },widgetIdentifier);
 
-		casper.wait(1000, function () {
-			var popupSize = casper.evaluate(function(widgetIdentifier) {
-				var widget = eval(widgetIdentifier);
-				return widget.getSize();
-			},widgetIdentifier);
+    casper.wait(1000, function () {
+      var popupSize = casper.evaluate(function (widgetIdentifier) {
+        var widget = eval(widgetIdentifier);
+        return widget.getSize();
+      },widgetIdentifier);
 
-			test.assertEquals(popupSize.width, originalWidth, widgetIdentifier+" restore width correct");
-			test.assertEquals(popupSize.height, originalHeight, widgetIdentifier+" restore height correct");    
-		});   		
-	});
+      test.assertEquals(popupSize.width, originalWidth, widgetIdentifier + " restore width correct");
+      test.assertEquals(popupSize.height, originalHeight, widgetIdentifier + " restore height correct");    
+    });
+  });
 }
 
-function testMinimizeWidget(test, widgetIdentifier){
-	//test widget is not yet minimized
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var minimizeBar = casper.evaluate(function(widgetIdentifier) {
-				return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
-			},widgetIdentifier);
+function testMinimizeWidget (test, widgetIdentifier){
+  // test widget is not yet minimized
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var minimizeBar = casper.evaluate(function (widgetIdentifier) {
+        return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
+      },widgetIdentifier);
 
-			test.assertEquals(minimizeBar, 0, widgetIdentifier+" not minimize, expected and passes correctly.");
-		});		
-	});
+      test.assertEquals(minimizeBar, 0, widgetIdentifier + " not minimize, expected and passes correctly.");
+    });
+  });
 
-	//minimize widget button call
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[3].click()
-		},widgetIdentifier);
-	});
+  // minimize widget button call
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[3].click()
+    },widgetIdentifier);
+  });
 
-	//locate minimized widget in corner of geppetto
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var minimizeBar = casper.evaluate(function(widgetIdentifier) {
-				return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
-			},widgetIdentifier);
+  // locate minimized widget in corner of geppetto
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var minimizeBar = casper.evaluate(function (widgetIdentifier) {
+        return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
+      },widgetIdentifier);
 
-			test.assertEquals(minimizeBar, 1, widgetIdentifier+" minimize correctly.");
-		});		
-	});
+      test.assertEquals(minimizeBar, 1, widgetIdentifier + " minimize correctly.");
+    });
+  });
 
-	//restore minimized widget
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[3].click()
-		},widgetIdentifier);
-	});
+  // restore minimized widget
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[3].click()
+    },widgetIdentifier);
+  });
 
-	//test restored widget is actually restored
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var minimizeBar = casper.evaluate(function(widgetIdentifier) {
-				return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
-			},widgetIdentifier);
+  // test restored widget is actually restored
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var minimizeBar = casper.evaluate(function (widgetIdentifier) {
+        return $("#dialog-extend-fixed-container").find(".ui-dialog").length;
+      },widgetIdentifier);
 
-			test.assertEquals(minimizeBar, 0, widgetIdentifier+" not minimize, expected and passes correctly.");
-		});		
-	});
+      test.assertEquals(minimizeBar, 0, widgetIdentifier + " not minimize, expected and passes correctly.");
+    });
+  });
 }
 
-function testCollapseWidget(test, widgetIdentifier){
-	//test widget is not yet collapsed
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var collapsedWidget = casper.evaluate(function(widgetIdentifier,collapsedWidgetHeight) {
-				return $("#"+widgetIdentifier).height()<collapsedWidgetHeight;
-			},widgetIdentifier,collapsedWidgetHeight);
+function testCollapseWidget (test, widgetIdentifier){
+  // test widget is not yet collapsed
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var collapsedWidget = casper.evaluate(function (widgetIdentifier,collapsedWidgetHeight) {
+        return $("#" + widgetIdentifier).height() < collapsedWidgetHeight;
+      },widgetIdentifier,collapsedWidgetHeight);
 
-			test.assertEquals(collapsedWidget, false, widgetIdentifier+" not collapsed, expected and passes correctly.");
-		});		
-	});
+      test.assertEquals(collapsedWidget, false, widgetIdentifier + " not collapsed, expected and passes correctly.");
+    });
+  });
 
-	//collapse widget
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[0].click()
-		},widgetIdentifier);
-	});
+  // collapse widget
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[0].click()
+    },widgetIdentifier);
+  });
 
-	//test collapsed widget is actually collapase
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var collapsedWidget = casper.evaluate(function(widgetIdentifier,collapsedWidgetHeight) {
-				return $("#"+widgetIdentifier).height()<collapsedWidgetHeight;
-			},widgetIdentifier,collapsedWidgetHeight);
+  // test collapsed widget is actually collapase
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var collapsedWidget = casper.evaluate(function (widgetIdentifier,collapsedWidgetHeight) {
+        return $("#" + widgetIdentifier).height() < collapsedWidgetHeight;
+      },widgetIdentifier,collapsedWidgetHeight);
 
-			test.assertEquals(collapsedWidget, true, widgetIdentifier+" collapsed, expected and passes correctly.");
-		});		
-	});
+      test.assertEquals(collapsedWidget, true, widgetIdentifier + " collapsed, expected and passes correctly.");
+    });
+  });
 
-	//restore collapsed widget
-	casper.then(function () {
-		casper.evaluate(function(widgetIdentifier) {
-			$("#"+widgetIdentifier).parent().find("a")[1].click()
-		},widgetIdentifier);
-	});
+  // restore collapsed widget
+  casper.then(function () {
+    casper.evaluate(function (widgetIdentifier) {
+      $("#" + widgetIdentifier).parent().find("a")[1].click()
+    },widgetIdentifier);
+  });
 
-	//test restored widget is not collapsed anymore
-	casper.then(function () {
-		casper.wait(1000, function () {
-			var collapsedWidget = casper.evaluate(function(widgetIdentifier,collapsedWidgetHeight) {
-				return $("#"+widgetIdentifier).height()<collapsedWidgetHeight;
-			},widgetIdentifier,collapsedWidgetHeight);
+  // test restored widget is not collapsed anymore
+  casper.then(function () {
+    casper.wait(1000, function () {
+      var collapsedWidget = casper.evaluate(function (widgetIdentifier,collapsedWidgetHeight) {
+        return $("#" + widgetIdentifier).height() < collapsedWidgetHeight;
+      },widgetIdentifier,collapsedWidgetHeight);
 
-			test.assertEquals(collapsedWidget, false, widgetIdentifier+" not collapsed, expected and passes correctly.");
-		});		
-	});
+      test.assertEquals(collapsedWidget, false, widgetIdentifier + " not collapsed, expected and passes correctly.");
+    });
+  });
 }
 
-function closeWidget(test, widgetIdentifier){
-	//destroy widget
-	casper.evaluate(function(widgetIdentifier) {
-		var widget = eval(widgetIdentifier);
-		return widget.destroy();
-	},widgetIdentifier);
+function closeWidget (test, widgetIdentifier){
+  // destroy widget
+  casper.evaluate(function (widgetIdentifier) {
+    var widget = eval(widgetIdentifier);
+    return widget.destroy();
+  },widgetIdentifier);
 
-	//test destroyed widget no longer exists
-	casper.waitWhileVisible('div[id="'+widgetIdentifier+'"]', function () {
-		this.echo("I've waited for " + widgetIdentifier + " to go away.");
-		test.assertDoesntExist('div[id="'+widgetIdentifier+'"]', widgetIdentifier+" doesn't exist after being destroyed.")
-	}); 		
+  // test destroyed widget no longer exists
+  casper.waitWhileVisible('div[id="' + widgetIdentifier + '"]', function () {
+    this.echo("I've waited for " + widgetIdentifier + " to go away.");
+    test.assertDoesntExist('div[id="' + widgetIdentifier + '"]', widgetIdentifier + " doesn't exist after being destroyed.")
+  });
 }

--- a/tests/casperjs/utilities/TestsUtility.js
+++ b/tests/casperjs/utilities/TestsUtility.js
@@ -1,6 +1,6 @@
 var urlBase = casper.cli.get('host');
-if(urlBase==null || urlBase==undefined){
-    urlBase = "http://127.0.0.1:8080/";
+if (urlBase == null || urlBase == undefined){
+  urlBase = "http://127.0.0.1:8080/";
 }
 var baseFollowUp = "org.geppetto.frontend/geppetto?";
 
@@ -16,63 +16,63 @@ var nwbSample = "load_project_from_id=18";
 var Pharyngeal = "load_project_from_id=58";
 var cylinders = "load_project_from_url=https://raw.githubusercontent.com/openworm/org.geppetto.samples/development/UsedInUnitTests/cylinder/geppetto.json";
 var defaultColor = [0.00392156862745098,0.6,0.9098039215686274];
-var zoomClicks = 50, panClicks=10, rotateClicks=20;
+var zoomClicks = 50, panClicks = 10, rotateClicks = 20;
 
-function launchTest(test, projectName, timeAllowed){
-    casper.waitWhileVisible('div[id="loading-spinner"]', function () {
-        this.echo("I've waited for "+projectName+" project to load.");
-        test.assertTitle("geppetto", "geppetto title is ok");
-        test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
-        test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
-        test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
-    },null,timeAllowed);
+function launchTest (test, projectName, timeAllowed){
+  casper.waitWhileVisible('div[id="loading-spinner"]', function () {
+    this.echo("I've waited for " + projectName + " project to load.");
+    test.assertTitle("geppetto", "geppetto title is ok");
+    test.assertExists('div[id="sim-toolbar"]', "geppetto loads the initial simulation controls");
+    test.assertExists('div[id="controls"]', "geppetto loads the initial camera controls");
+    test.assertExists('div[id="foreground-toolbar"]', "geppetto loads the initial foreground controls");
+  },null,timeAllowed);
 }
 
-function resetCameraTest(test,expectedCameraPosition){
-    buttonClick("#panHomeBtn");
-    testCameraPosition(test,expectedCameraPosition);
+function resetCameraTest (test,expectedCameraPosition){
+  buttonClick("#panHomeBtn");
+  testCameraPosition(test,expectedCameraPosition);
 }
 
-function resetCameraTestWithCanvasWidget(test,expectedCameraPosition){
-    buttonClick("#panHomeBtn");
-    casper.evaluate(function(){
-        $("#Canvas2_component").find(".position-toolbar").find(".pan-home").click();
+function resetCameraTestWithCanvasWidget (test,expectedCameraPosition){
+  buttonClick("#panHomeBtn");
+  casper.evaluate(function (){
+    $("#Canvas2_component").find(".position-toolbar").find(".pan-home").click();
+  });
+  testCameraPosition(test,expectedCameraPosition);
+}
+
+function testInitialControlPanelValues (test, values){
+  casper.waitUntilVisible('div#controlpanel', function () {
+    test.assertVisible('div#controlpanel', "The control panel is correctly open.");
+    var rows = casper.evaluate(function () {
+      var rows = $(".standard-row").length;
+      return rows;
     });
-    testCameraPosition(test,expectedCameraPosition);
+    test.assertEquals(rows, values, "The control panel opened with right amount of rows");
+  });
 }
 
-function testInitialControlPanelValues(test, values){
-    casper.waitUntilVisible('div#controlpanel', function () {
-        test.assertVisible('div#controlpanel', "The control panel is correctly open.");
-        var rows = casper.evaluate(function() {
-            var rows = $(".standard-row").length;
-            return rows;
-        });
-        test.assertEquals(rows, values, "The control panel opened with right amount of rows");
+function removeAllPlots (){
+  casper.then(function (){
+    casper.evaluate(function () {
+      $("div.js-plotly-plot").remove();
     });
+    this.wait(1000, function () {});
+  });
 }
 
-function removeAllPlots(){
-    casper.then(function(){
-        casper.evaluate(function() {
-            $("div.js-plotly-plot").remove();
-        });
-        this.wait(1000, function () {});
+function removeAllDialogs (){
+  casper.then(function (){
+    casper.evaluate(function () {
+      $("div.dialog").remove();
     });
+  });
 }
 
-function removeAllDialogs(){
-    casper.then(function(){
-        casper.evaluate(function() {
-            $("div.dialog").remove();
-        });
-    });
-}
-
-function buttonClick(buttonName){
-    casper.evaluate(function(buttonName) {
-        $(buttonName).click();
-    },buttonName);
+function buttonClick (buttonName){
+  casper.evaluate(function (buttonName) {
+    $(buttonName).click();
+  },buttonName);
 }
 /**
  * Tests visibility of a mesh
@@ -81,26 +81,26 @@ function buttonClick(buttonName){
  * @param buttonName
  * @returns
  */
-function testVisibility(test,variableName, buttonName){
-    casper.then(function(){
-        testMeshVisibility(test,true,variableName);
-    });
+function testVisibility (test,variableName, buttonName){
+  casper.then(function (){
+    testMeshVisibility(test,true,variableName);
+  });
 
-    casper.then(function(){
-        buttonClick(buttonName);
-    });
+  casper.then(function (){
+    buttonClick(buttonName);
+  });
 
-    casper.then(function(){
-        testMeshVisibility(test,false,variableName);
-    });
+  casper.then(function (){
+    testMeshVisibility(test,false,variableName);
+  });
 
-    casper.then(function(){
-        buttonClick(buttonName);
-    });
+  casper.then(function (){
+    buttonClick(buttonName);
+  });
 
-    casper.then(function(){
-        testMeshVisibility(test,true,variableName);
-    });
+  casper.then(function (){
+    testMeshVisibility(test,true,variableName);
+  });
 }
 
 /**
@@ -110,13 +110,13 @@ function testVisibility(test,variableName, buttonName){
  * @param variableName
  * @returns
  */
-function testMeshVisibility(test,visible,variableName){
-    var visibility = casper.evaluate(function(variableName) {
-        var visibility = Canvas1.engine.getRealMeshesForInstancePath(variableName)[0].visible;
-        return visibility;
-    },variableName);
+function testMeshVisibility (test,visible,variableName){
+  var visibility = casper.evaluate(function (variableName) {
+    var visibility = Canvas1.engine.getRealMeshesForInstancePath(variableName)[0].visible;
+    return visibility;
+  },variableName);
 
-    test.assertEquals(visibility,visible, variableName +" visibility correct");
+  test.assertEquals(visibility,visible, variableName + " visibility correct");
 }
 
 /**
@@ -125,20 +125,20 @@ function testMeshVisibility(test,visible,variableName){
  * @param expectedCamPosition
  * @returns
  */
-function testCameraPosition(test,expectedCamPosition){
-    var camPosition = casper.evaluate(function() {
-        var position = Canvas1.engine.camera.position;
-        return [position.x, position.y, position.z];
-    });
+function testCameraPosition (test,expectedCamPosition){
+  var camPosition = casper.evaluate(function () {
+    var position = Canvas1.engine.camera.position;
+    return [position.x, position.y, position.z];
+  });
 
-    for (var i in camPosition){
-        camPosition[i] = parseFloat(camPosition[i].toFixed(2))
-        expectedCamPosition[i] = parseFloat(expectedCamPosition[i].toFixed(2))
-    }
+  for (var i in camPosition){
+    camPosition[i] = parseFloat(camPosition[i].toFixed(2))
+    expectedCamPosition[i] = parseFloat(expectedCamPosition[i].toFixed(2))
+  }
 
-    test.assertEquals( camPosition[0],expectedCamPosition[0], "Vector's x coordinate is correct as camera position");
-    test.assertEquals( camPosition[1],expectedCamPosition[1], "Vector's y coordinate is correct as camera position");
-    test.assertEquals( camPosition[2],expectedCamPosition[2], "Vector's z coordinate is correct as camera position");
+  test.assertEquals( camPosition[0],expectedCamPosition[0], "Vector's x coordinate is correct as camera position");
+  test.assertEquals( camPosition[1],expectedCamPosition[1], "Vector's y coordinate is correct as camera position");
+  test.assertEquals( camPosition[2],expectedCamPosition[2], "Vector's z coordinate is correct as camera position");
 }
 
 /**
@@ -148,41 +148,41 @@ function testCameraPosition(test,expectedCamPosition){
  * @param variableName
  * @returns
  */
-function test3DMeshColor(test,testColor,variableName,index){
-    if(index==undefined){
-        index=0;
-    }
-    var color = casper.evaluate(function(variableName,index) {
-        var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
-        return [color.r, color.g, color.b];
-    },variableName,index);
+function test3DMeshColor (test,testColor,variableName,index){
+  if (index == undefined){
+    index = 0;
+  }
+  var color = casper.evaluate(function (variableName,index) {
+    var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
+    return [color.r, color.g, color.b];
+  },variableName,index);
 
-    test.assertEquals(color[0],testColor[0], "Red default color is correct for "+ variableName);
-    test.assertEquals(color[1],testColor[1],"Green default color is correct for " + variableName);
-    test.assertEquals(color[2],testColor[2],"Blue default color is correct for " +variableName);
+  test.assertEquals(color[0],testColor[0], "Red default color is correct for " + variableName);
+  test.assertEquals(color[1],testColor[1],"Green default color is correct for " + variableName);
+  test.assertEquals(color[2],testColor[2],"Blue default color is correct for " + variableName);
 }
 
-function getMeshColor(test,variableName,index){
-    if(index==undefined){
-        index=0;
-    }
-    var color = casper.evaluate(function(variableName,index) {
-        var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
-        return [color.r, color.g, color.b];
-    },variableName,index);
-    return color;
+function getMeshColor (test,variableName,index){
+  if (index == undefined){
+    index = 0;
+  }
+  var color = casper.evaluate(function (variableName,index) {
+    var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
+    return [color.r, color.g, color.b];
+  },variableName,index);
+  return color;
 }
 
-function test3DMeshOpacity(test,opactityExpected,variableName,index){
-    if(index==undefined){
-        index=0;
-    }
-    var opacity = casper.evaluate(function(variableName,index) {
-        var opacity = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.opacity;
-        return opacity;
-    },variableName,index);
+function test3DMeshOpacity (test,opactityExpected,variableName,index){
+  if (index == undefined){
+    index = 0;
+  }
+  var opacity = casper.evaluate(function (variableName,index) {
+    var opacity = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.opacity;
+    return opacity;
+  },variableName,index);
 
-    test.assertEquals(opacity,opactityExpected, "Opacity is correct for "+ variableName);
+  test.assertEquals(opacity,opactityExpected, "Opacity is correct for " + variableName);
 }
 
 /**
@@ -192,18 +192,18 @@ function test3DMeshOpacity(test,opactityExpected,variableName,index){
  * @param variableName
  * @returns
  */
-function test3DMeshColorNotEquals(test,testColor,variableName,index){
-    if(index==undefined){
-        index=0;
-    }
-    var color = casper.evaluate(function(variableName,index) {
-        var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
-        return [color.r, color.g, color.b];
-    },variableName,index);
+function test3DMeshColorNotEquals (test,testColor,variableName,index){
+  if (index == undefined){
+    index = 0;
+  }
+  var color = casper.evaluate(function (variableName,index) {
+    var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[index].material.color;
+    return [color.r, color.g, color.b];
+  },variableName,index);
 
-    test.assertNotEquals(testColor[0], color[0], "Red default color is correctly different for "+ variableName);
-    test.assertNotEquals(testColor[1], color[1], "Green default color is correctly different for " + variableName);
-    test.assertNotEquals(testColor[2], color[2], "Blue default color is correctly different for " +variableName);
+  test.assertNotEquals(testColor[0], color[0], "Red default color is correctly different for " + variableName);
+  test.assertNotEquals(testColor[1], color[1], "Green default color is correctly different for " + variableName);
+  test.assertNotEquals(testColor[2], color[2], "Blue default color is correctly different for " + variableName);
 }
 
 /**
@@ -213,29 +213,29 @@ function test3DMeshColorNotEquals(test,testColor,variableName,index){
  * @param selectColorVarName - Expected color to find in istance's mesh material
  * @returns
  */
-function testSelection(test,variableName,selectColorVarName){
-    buttonClick("#spotlightBtn");
-    casper.echo("---testSelection----");
-    casper.waitUntilVisible('div#spotlight', function () {
-        casper.sendKeys('input#typeahead', variableName, {keepFocus: true});
-        casper.sendKeys('input#typeahead', casper.page.event.key.Return, {keepFocus: true});
-        casper.waitUntilVisible('button#buttonOne', function () {
-            test.assertVisible('button#buttonOne', "Select button correctly visible");
-            buttonClick("#buttonOne");
-            this.wait(500, function () {
-                var selectColor = [1,0.8,0];
-                casper.echo("---test3DMeshColor----");
-                test3DMeshColor(test,selectColor,selectColorVarName,0);
-            });
-        });
+function testSelection (test,variableName,selectColorVarName){
+  buttonClick("#spotlightBtn");
+  casper.echo("---testSelection----");
+  casper.waitUntilVisible('div#spotlight', function () {
+    casper.sendKeys('input#typeahead', variableName, { keepFocus: true });
+    casper.sendKeys('input#typeahead', casper.page.event.key.Return, { keepFocus: true });
+    casper.waitUntilVisible('button#buttonOne', function () {
+      test.assertVisible('button#buttonOne', "Select button correctly visible");
+      buttonClick("#buttonOne");
+      this.wait(500, function () {
+        var selectColor = [1,0.8,0];
+        casper.echo("---test3DMeshColor----");
+        test3DMeshColor(test,selectColor,selectColorVarName,0);
+      });
     });
+  });
 }
 
-function closeSpotlight(){
-    casper.evaluate(function() {
-        $("#spotlight").hide();
-    });
-    casper.echo("Clicking to close spotlight");
+function closeSpotlight (){
+  casper.evaluate(function () {
+    $("#spotlight").hide();
+  });
+  casper.echo("Clicking to close spotlight");
 }
 
 /**
@@ -249,49 +249,49 @@ function closeSpotlight(){
  * @param selectColorVarName
  * @returns
  */
-function testSpotlight(test, variableName,plotName,expectButton,testSelect, selectionName, selectColorVarName){
-    test.assertExists('i.fa-search', "Spotlight button exists")
-    casper.mouseEvent('click', 'i.fa-search', "attempting to open spotlight");
+function testSpotlight (test, variableName,plotName,expectButton,testSelect, selectionName, selectColorVarName){
+  test.assertExists('i.fa-search', "Spotlight button exists")
+  casper.mouseEvent('click', 'i.fa-search', "attempting to open spotlight");
+
+  casper.waitUntilVisible('div#spotlight', function () {
+    test.assertVisible('div#spotlight', "Spotlight opened");
+
+    // type in the spotlight
+    this.sendKeys('input#typeahead', variableName, { keepFocus: true });
+    // press enter
+    this.sendKeys('input#typeahead', this.page.event.key.Return, { keepFocus: true });
 
     casper.waitUntilVisible('div#spotlight', function () {
-        test.assertVisible('div#spotlight', "Spotlight opened");
-
-        //type in the spotlight
-        this.sendKeys('input#typeahead', variableName, {keepFocus: true});
-        //press enter
-        this.sendKeys('input#typeahead', this.page.event.key.Return, {keepFocus: true});
-
-        casper.waitUntilVisible('div#spotlight', function () {
-            casper.then(function () {
-                this.echo("Waiting to see if the Plot variables button becomes visible");
-                if(expectButton){
-                    casper.waitUntilVisible('button#plot', function () {
-                        test.assertVisible('button#plot', "Plot variables icon correctly visible");
-                        this.echo("Plot variables button became visible correctly");
-                        buttonClick("#plot");
-                        this.waitUntilVisible(plotName, function () {
-                            this.echo("Plot 2 came up correctly");
-                            if(testSelect){
-                                testSelection(test, selectionName,selectColorVarName);
-                            }
-                        });
-                    }, null, 5000);
-                }else{
-                    casper.wait(1000, function () {
-                        casper.then(function () {
-                            this.echo("Waiting to see if the Plot and watch variable buttons becomes visible");
-                            test.assertDoesntExist('button#plot', "Plot variables icon correctly invisible");
-                            test.assertDoesntExist('button#watch', "Watch button correctly hidden");
-                            this.echo("Variables button are hidden correctly");
-                            if(testSelect){
-                                testSelection(test, selectionName,selectColorVarName);
-                            }
-                        });
-                    });
-                }
+      casper.then(function () {
+        this.echo("Waiting to see if the Plot variables button becomes visible");
+        if (expectButton){
+          casper.waitUntilVisible('button#plot', function () {
+            test.assertVisible('button#plot', "Plot variables icon correctly visible");
+            this.echo("Plot variables button became visible correctly");
+            buttonClick("#plot");
+            this.waitUntilVisible(plotName, function () {
+              this.echo("Plot 2 came up correctly");
+              if (testSelect){
+                testSelection(test, selectionName,selectColorVarName);
+              }
             });
-        });
+          }, null, 5000);
+        } else {
+          casper.wait(1000, function () {
+            casper.then(function () {
+              this.echo("Waiting to see if the Plot and watch variable buttons becomes visible");
+              test.assertDoesntExist('button#plot', "Plot variables icon correctly invisible");
+              test.assertDoesntExist('button#watch', "Watch button correctly hidden");
+              this.echo("Variables button are hidden correctly");
+              if (testSelect){
+                testSelection(test, selectionName,selectColorVarName);
+              }
+            });
+          });
+        }
+      });
     });
+  });
 }
 
 /**
@@ -300,34 +300,34 @@ function testSpotlight(test, variableName,plotName,expectButton,testSelect, sele
  * @param expectedCameraPosition
  * @returns
  */
-function testCameraControls(test, expectedCameraPosition){
-    casper.then(function(){
-        casper.echo("------Zoom-------");
-        casper.repeat(zoomClicks, function() {
-            this.thenClick("button#zoomInBtn", function() {});
-        });
-    });//zoom in
-    casper.then(function(){
-        resetCameraTest(test, expectedCameraPosition);
-    });//reset home camera position
-    casper.then(function(){
-        casper.echo("------Pan-------");
-        casper.repeat(panClicks, function() {
-            this.thenClick("button#panRightBtn", function(){});
-        });
-    });//pan right test
-    casper.then(function(){
-        resetCameraTest(test, expectedCameraPosition);
-    });//reset home position
-    casper.then(function(){
-        casper.echo("------Rotate-------");
-        casper.repeat(rotateClicks, function() {
-            this.thenClick("button#rotateRightBtn", function(){});
-        });
-    });//rotate test
-    casper.then(function(){
-        resetCameraTest(test, expectedCameraPosition);
-    });//reset home
+function testCameraControls (test, expectedCameraPosition){
+  casper.then(function (){
+    casper.echo("------Zoom-------");
+    casper.repeat(zoomClicks, function () {
+      this.thenClick("button#zoomInBtn", function () {});
+    });
+  });// zoom in
+  casper.then(function (){
+    resetCameraTest(test, expectedCameraPosition);
+  });// reset home camera position
+  casper.then(function (){
+    casper.echo("------Pan-------");
+    casper.repeat(panClicks, function () {
+      this.thenClick("button#panRightBtn", function (){});
+    });
+  });// pan right test
+  casper.then(function (){
+    resetCameraTest(test, expectedCameraPosition);
+  });// reset home position
+  casper.then(function (){
+    casper.echo("------Rotate-------");
+    casper.repeat(rotateClicks, function () {
+      this.thenClick("button#rotateRightBtn", function (){});
+    });
+  });// rotate test
+  casper.then(function (){
+    resetCameraTest(test, expectedCameraPosition);
+  });// reset home
 }
 
 /**
@@ -336,80 +336,80 @@ function testCameraControls(test, expectedCameraPosition){
  * @param expectedCameraPosition
  * @returns
  */
-function testCameraControlsWithCanvasWidget(test, expectedCameraPosition){
-    casper.echo("-------Testing Camera Controls while playing experiment--------");
-    casper.then(function(){
-        casper.echo("------Zoom-------");
-        casper.repeat(zoomClicks*2, function() {
-            this.thenClick("button#zoomInBtn", function() {});
-            this.thenClick("#Canvas2 button#zoomInBtn", function() {});
-        });
-    });//zoom in
-    casper.then(function(){
-        resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
-    });//reset home camera position
-    casper.then(function(){
-        casper.echo("------Pan-------");
-        casper.repeat(panClicks*2, function() {
-            this.thenClick("button#panRightBtn", function(){});
-            this.thenClick("#Canvas2 button#panRightBtn", function(){});
-        });
-    });//pan right test
-    casper.then(function(){
-        resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
-    });//reset home position
-    casper.then(function(){
-        casper.echo("------Rotate-------");
-        casper.repeat(rotateClicks*2, function() {
-            this.thenClick("button#rotateRightBtn", function(){});
-            this.thenClick("#Canvas2 button#rotateRightBtn", function(){});
-        });
-    });//rotate test
-    casper.then(function(){
-        resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
-    });//reset home
-}
-
-function testVisualGroup(test,variableName, expectedMeshes,expectedColors){
-    casper.then(function(){
-        casper.echo("-------Testing Highlighted Instance--------");
-        var i=1;
-        casper.repeat(expectedMeshes, function() {
-            casper.echo("Debug Log: variableName "+ variableName+" and i ="+i);
-            var color = casper.evaluate(function(variableName,i) {
-                var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[i].material.color;
-                return [color.r, color.g, color.b];
-            },variableName,i);
-            test3DMeshColorNotEquals(test,color, variableName);
-            test3DMeshColor(test,expectedColors[i], variableName,i);
-            ++i;
-        });
+function testCameraControlsWithCanvasWidget (test, expectedCameraPosition){
+  casper.echo("-------Testing Camera Controls while playing experiment--------");
+  casper.then(function (){
+    casper.echo("------Zoom-------");
+    casper.repeat(zoomClicks * 2, function () {
+      this.thenClick("button#zoomInBtn", function () {});
+      this.thenClick("#Canvas2 button#zoomInBtn", function () {});
     });
-}
-
-function testingConnectionLines(test, expectedLines){
-    casper.then(function(){
-        var connectionLines = casper.evaluate(function() {
-            var connectionLines = Object.keys(Canvas1.engine.connectionLines).length;
-            return connectionLines;
-        });
-        test.assertEquals(expectedLines, connectionLines, "Right amount of connections line");
+  });// zoom in
+  casper.then(function (){
+    resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
+  });// reset home camera position
+  casper.then(function (){
+    casper.echo("------Pan-------");
+    casper.repeat(panClicks * 2, function () {
+      this.thenClick("button#panRightBtn", function (){});
+      this.thenClick("#Canvas2 button#panRightBtn", function (){});
     });
+  });// pan right test
+  casper.then(function (){
+    resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
+  });// reset home position
+  casper.then(function (){
+    casper.echo("------Rotate-------");
+    casper.repeat(rotateClicks * 2, function () {
+      this.thenClick("button#rotateRightBtn", function (){});
+      this.thenClick("#Canvas2 button#rotateRightBtn", function (){});
+    });
+  });// rotate test
+  casper.then(function (){
+    resetCameraTestWithCanvasWidget(test, expectedCameraPosition);
+  });// reset home
 }
 
-function testMoviePlayerWidget(test,id){
-    test.assertExists('div[id="'+id+'"]', "Movie player exists");
-    test.assertExists("iframe[id=\"widget6\"]", "Movie player iframe exists");
+function testVisualGroup (test,variableName, expectedMeshes,expectedColors){
+  casper.then(function (){
+    casper.echo("-------Testing Highlighted Instance--------");
+    var i = 1;
+    casper.repeat(expectedMeshes, function () {
+      casper.echo("Debug Log: variableName " + variableName + " and i =" + i);
+      var color = casper.evaluate(function (variableName,i) {
+        var color = Canvas1.engine.getRealMeshesForInstancePath(variableName)[i].material.color;
+        return [color.r, color.g, color.b];
+      },variableName,i);
+      test3DMeshColorNotEquals(test,color, variableName);
+      test3DMeshColor(test,expectedColors[i], variableName,i);
+      ++i;
+    });
+  });
 }
 
-function testPlotWidgets(test, widget, variableName, expectedGElements){
-	test.assertExists('div[id="'+widget+'"]', "Plot widget exists")
+function testingConnectionLines (test, expectedLines){
+  casper.then(function (){
+    var connectionLines = casper.evaluate(function () {
+      var connectionLines = Object.keys(Canvas1.engine.connectionLines).length;
+      return connectionLines;
+    });
+    test.assertEquals(expectedLines, connectionLines, "Right amount of connections line");
+  });
+}
 
-	casper.then(function(){
-		var gElements = casper.evaluate(function(widget, expectedGElements) {
-			var gElements = $("#"+widget)[0].getElementsByClassName("legendtoggle").length;
-			return gElements;
-		}, widget, expectedGElements);
-		test.assertEquals(gElements, expectedGElements, "Right amount of graph elements for "+widget);
-	});
+function testMoviePlayerWidget (test,id){
+  test.assertExists('div[id="' + id + '"]', "Movie player exists");
+  test.assertExists("iframe[id=\"widget6\"]", "Movie player iframe exists");
+}
+
+function testPlotWidgets (test, widget, variableName, expectedGElements){
+  test.assertExists('div[id="' + widget + '"]', "Plot widget exists")
+
+  casper.then(function (){
+    var gElements = casper.evaluate(function (widget, expectedGElements) {
+      var gElements = $("#" + widget)[0].getElementsByClassName("legendtoggle").length;
+      return gElements;
+    }, widget, expectedGElements);
+    test.assertEquals(gElements, expectedGElements, "Right amount of graph elements for " + widget);
+  });
 }

--- a/tests/qunit/ExternalSimulatorTests.js
+++ b/tests/qunit/ExternalSimulatorTests.js
@@ -1,115 +1,116 @@
 
 define(function (require) {
-    var QUnit = require("qunitjs");
-    require('../../../components/ComponentFactory')(GEPPETTO);
-    global.GEPPETTO_CONFIGURATION = require('../../../../GeppettoConfiguration.json');
-    /**
-     * Calls "start()" from QUnit to start qunit tests, closes socket and clears
-     * handlers. Method is called from each test.
-     */
-    function resetConnection() {
-        //close socket
-        GEPPETTO.MessageSocket.close();
-        //clear message handlers, all tests within module should have performed by time method it's called
-        GEPPETTO.MessageSocket.clearHandlers();
-        //connect to socket again for next test
-        GEPPETTO.MessageSocket.connect(GEPPETTO.MessageSocket.protocol + window.location.host + '/' + GEPPETTO_CONFIGURATION.contextPath + '/GeppettoServlet');
-    }
+  var QUnit = require("qunitjs");
+  var path = require('path');
+  require('../../../components/ComponentFactory')(GEPPETTO);
+  global.GEPPETTO_CONFIGURATION = require('root/GeppettoConfiguration.json');
+  /**
+   * Calls "start()" from QUnit to start qunit tests, closes socket and clears
+   * handlers. Method is called from each test.
+   */
+  function resetConnection () {
+    // close socket
+    GEPPETTO.MessageSocket.close();
+    // clear message handlers, all tests within module should have performed by time method it's called
+    GEPPETTO.MessageSocket.clearHandlers();
+    // connect to socket again for next test
+    GEPPETTO.MessageSocket.connect(GEPPETTO.MessageSocket.protocol + window.location.host + '/' + GEPPETTO_CONFIGURATION.contextPath + '/GeppettoServlet');
+  }
 
-    var run = function () {
+  var run = function () {
 
-        QUnit.module("Project 1 - SingleComponentHH - Not testing anything");
-        QUnit.test("Tests Neuron Experiment - Not testing anything", function ( assert ) {
+    QUnit.module("Project 1 - SingleComponentHH - Not testing anything");
+    QUnit.test("Tests Neuron Experiment - Not testing anything", function ( assert ) {
 
-            assert.ok(true, "Empty test");
-            /*
-            var initializationTime;
-            var handler = {
-                onMessage: function (parsedServerMessage) {
-                    // Switch based on parsed incoming message type
-                    switch (parsedServerMessage.type) {
-                        case GEPPETTO.MessageHandler.MESSAGE_TYPE.PROJECT_LOADED:
-                            var time = (new Date() - initializationTime) / 1000;
-                            GEPPETTO.Manager.loadProject(JSON.parse(parsedServerMessage.data));
-                            assert.equal(window.Project.getId(), 1, "Project loaded ID checked");
-                            break;
-                        case GEPPETTO.MessageHandler.MESSAGE_TYPE.MODEL_LOADED:
-                            GEPPETTO.Manager.loadModel(payload);
-                            break
-                        case GEPPETTO.MessageHandler.MESSAGE_TYPE.EXPERIMENT_LOADED:
-                            var time = (new Date() - initializationTime) / 1000;
-                            var payload = JSON.parse(parsedServerMessage.data);
-                            var newExperiment = GEPPETTO.Manager.loadExperiment(payload);
-
-                            assert.equal(window.Project.getActiveExperiment().getId(), 1, "Experiment id of loaded project checked");
-
-                            window.Project.getActiveExperiment().run();
-                            break;
-                        case GEPPETTO.MessageHandler.MESSAGE_TYPE.EXPERIMENT_STATUS:
-                            var time = (new Date() - initializationTime) / 1000;
-                            var payload = JSON.parse(parsedServerMessage.data);
-                            var experimentStatus = JSON.parse(payload.update);
-
-                            var experiments = window.Project.getExperiments();
-                            for (var key in experimentStatus) {
-                                var projectID = experimentStatus[key].projectID;
-                                var status = experimentStatus[key].status;
-                                var experimentID = experimentStatus[key].experimentID;
-
-                                //changing status in matched experiment
-                                for (var e in experiments) {
-                                    if (experiments[e].getId() == experimentID) {
-                                        if (experiments[e].getStatus() != status) {
-                                            if (window.Project.getActiveExperiment() != null || undefined) {
-                                                if (window.Project.getActiveExperiment().getId() == experimentID) {
-                                                    if (experiments[e].getStatus() == GEPPETTO.Resources.ExperimentStatus.RUNNING &&
-                                                        status == GEPPETTO.Resources.ExperimentStatus.COMPLETED) {
-                                                    	assert.ok(true, "project loaded");
-                                                        done();
-                                                        resetConnection();
-                                                    }
-                                                }
-                                            }
-                                            experiments[e].setStatus(status);
-                                        }
-                                    }
-                                }
-                            }
-                            break;
-                        case GEPPETTO.GlobalHandler.MESSAGE_TYPE.INFO_MESSAGE:
-                            var payload = JSON.parse(parsedServerMessage.data);
-                            var message = JSON.parse(payload.message);
-                            assert.ok(false, message);
-
-                            done();
-                            resetConnection();
-                            break;
-                        case GEPPETTO.GlobalHandler.MESSAGE_TYPE.ERROR:
-                            var payload = JSON.parse(parsedServerMessage.data);
-                            var message = JSON.parse(payload.message).message;
-                            assert.ok(false, message);
-
-                            done();
-                            resetConnection();
-                            break;
-                        case GEPPETTO.GlobalHandler.MESSAGE_TYPE.ERROR_LOADING_PROJECT:
-                            var payload = JSON.parse(parsedServerMessage.data);
-                            var message = payload.message;
-                            assert.ok(false, message);
-
-                            done();
-                            resetConnection();
-                            break;
-                    }
-                }
-            };
-
-            GEPPETTO.MessageSocket.clearHandlers();
-            GEPPETTO.MessageSocket.addHandler(handler);
-            window.Project.loadFromID("1", "1");
-            initializationTime = new Date();
-            */
-        });
-    };
-    return {run: run};
+      assert.ok(true, "Empty test");
+      /*
+       * var initializationTime;
+       * var handler = {
+       * onMessage: function (parsedServerMessage) {
+       * // Switch based on parsed incoming message type
+       * switch (parsedServerMessage.type) {
+       * case GEPPETTO.MessageHandler.MESSAGE_TYPE.PROJECT_LOADED:
+       * var time = (new Date() - initializationTime) / 1000;
+       * GEPPETTO.Manager.loadProject(JSON.parse(parsedServerMessage.data));
+       * assert.equal(window.Project.getId(), 1, "Project loaded ID checked");
+       * break;
+       * case GEPPETTO.MessageHandler.MESSAGE_TYPE.MODEL_LOADED:
+       * GEPPETTO.Manager.loadModel(payload);
+       * break
+       * case GEPPETTO.MessageHandler.MESSAGE_TYPE.EXPERIMENT_LOADED:
+       * var time = (new Date() - initializationTime) / 1000;
+       * var payload = JSON.parse(parsedServerMessage.data);
+       * var newExperiment = GEPPETTO.Manager.loadExperiment(payload);
+       *
+       * assert.equal(window.Project.getActiveExperiment().getId(), 1, "Experiment id of loaded project checked");
+       *
+       * window.Project.getActiveExperiment().run();
+       * break;
+       * case GEPPETTO.MessageHandler.MESSAGE_TYPE.EXPERIMENT_STATUS:
+       * var time = (new Date() - initializationTime) / 1000;
+       * var payload = JSON.parse(parsedServerMessage.data);
+       * var experimentStatus = JSON.parse(payload.update);
+       *
+       * var experiments = window.Project.getExperiments();
+       * for (var key in experimentStatus) {
+       * var projectID = experimentStatus[key].projectID;
+       * var status = experimentStatus[key].status;
+       * var experimentID = experimentStatus[key].experimentID;
+       *
+       * //changing status in matched experiment
+       * for (var e in experiments) {
+       * if (experiments[e].getId() == experimentID) {
+       * if (experiments[e].getStatus() != status) {
+       * if (window.Project.getActiveExperiment() != null || undefined) {
+       * if (window.Project.getActiveExperiment().getId() == experimentID) {
+       * if (experiments[e].getStatus() == GEPPETTO.Resources.ExperimentStatus.RUNNING &&
+       * status == GEPPETTO.Resources.ExperimentStatus.COMPLETED) {
+       * assert.ok(true, "project loaded");
+       * done();
+       * resetConnection();
+       * }
+       * }
+       * }
+       * experiments[e].setStatus(status);
+       * }
+       * }
+       * }
+       * }
+       * break;
+       * case GEPPETTO.GlobalHandler.MESSAGE_TYPE.INFO_MESSAGE:
+       * var payload = JSON.parse(parsedServerMessage.data);
+       * var message = JSON.parse(payload.message);
+       * assert.ok(false, message);
+       *
+       * done();
+       * resetConnection();
+       * break;
+       * case GEPPETTO.GlobalHandler.MESSAGE_TYPE.ERROR:
+       * var payload = JSON.parse(parsedServerMessage.data);
+       * var message = JSON.parse(payload.message).message;
+       * assert.ok(false, message);
+       *
+       * done();
+       * resetConnection();
+       * break;
+       * case GEPPETTO.GlobalHandler.MESSAGE_TYPE.ERROR_LOADING_PROJECT:
+       * var payload = JSON.parse(parsedServerMessage.data);
+       * var message = payload.message;
+       * assert.ok(false, message);
+       *
+       * done();
+       * resetConnection();
+       * break;
+       * }
+       * }
+       * };
+       *
+       * GEPPETTO.MessageSocket.clearHandlers();
+       * GEPPETTO.MessageSocket.addHandler(handler);
+       * window.Project.loadFromID("1", "1");
+       * initializationTime = new Date();
+       */
+    });
+  };
+  return { run: run };
 });

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,21 +1,21 @@
 var webpackBaseConfig = require('./webpack.config.js');
 var extended = webpackBaseConfig();
 extended.devServer = {
-	progress : true,
-	port : 8081,
-	inline : true,
+  progress : true,
+  port : 8081,
+  inline : true,
 
-	proxy : [ {
-		path : '/',
-		target : 'http://localhost:8080/'
-	}, {
-		path : '/geppetto',
-		target : 'http://localhost:8080/org.geppetto.frontend'
-	}, {
-		path : '/org.geppetto.frontend',
-		target : 'ws://localhost:8080',
-		ws : true
-	}, ],
+  proxy : [ {
+    path : '/',
+    target : 'http://localhost:8080/'
+  }, {
+    path : '/geppetto',
+    target : 'http://localhost:8080/org.geppetto.frontend'
+  }, {
+    path : '/org.geppetto.frontend',
+    target : 'ws://localhost:8080',
+    ws : true
+  }, ],
 };
 
 extended.devtool = 'source-map';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,15 +3,17 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
-//var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-// <%=htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION._webapp_folder%>
+/*
+ *var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+ * <%=htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION._webapp_folder%>
+ */
 var geppettoConfig;
 try {
-    geppettoConfig = require('./GeppettoConfiguration.json');
-    console.log('\nLoaded Geppetto config from file');
+  geppettoConfig = require('./GeppettoConfiguration.json');
+  console.log('\nLoaded Geppetto config from file');
 } catch (e) {
-    // Failed to load config file
-    console.error('\nFailed to load Geppetto Configuration')
+  // Failed to load config file
+  console.error('\nFailed to load Geppetto Configuration')
 }
 var geppetto_client_path = 'node_modules/@geppettoengine/geppetto-client'
 
@@ -25,152 +27,152 @@ const availableExtensions = [
   { from: path.resolve(__dirname, geppetto_client_path, "static/*"), to: 'static', flatten: true },
 ];
 
-module.exports = function(env){
-  //geppettoConfig._webapp_folder
-	if(env!=undefined){
-		console.log(env);
-		if(env.contextPath){
-			geppettoConfig.contextPath=env.contextPath;
-		}
-		if(env.useSsl){
-			geppettoConfig.useSsl= JSON.parse(env.useSsl);
-		}
-		if(env.noTest){
-			geppettoConfig.noTest= JSON.parse(env.noTest);
-		}
-		if(env.embedded){
-			geppettoConfig.embedded= JSON.parse(env.embedded);
-		}
-		if(env.embedderURL){
-			geppettoConfig.embedderURL=env.embedderURL;
-		}
-	}
-	
-	console.log('Geppetto configuration \n');
-	console.log(JSON.stringify(geppettoConfig, null, 2), '\n');
-  
-	var entries = {
-        main: path.resolve(__dirname, "ComponentsInitialization.js"),
-        admin: path.resolve(__dirname, geppetto_client_path, "js/pages/admin/admin.js"),
-	};
+module.exports = function (env){
+  // geppettoConfig._webapp_folder
+  if (env != undefined){
+    console.log(env);
+    if (env.contextPath){
+      geppettoConfig.contextPath = env.contextPath;
+    }
+    if (env.useSsl){
+      geppettoConfig.useSsl = JSON.parse(env.useSsl);
+    }
+    if (env.noTest){
+      geppettoConfig.noTest = JSON.parse(env.noTest);
+    }
+    if (env.embedded){
+      geppettoConfig.embedded = JSON.parse(env.embedded);
+    }
+    if (env.embedderURL){
+      geppettoConfig.embedderURL = env.embedderURL;
+    }
+  }
 
-	console.log("\nThe Webpack entries are:");
+  console.log('Geppetto configuration \n');
+  console.log(JSON.stringify(geppettoConfig, null, 2), '\n');
+  
+  var entries = {
+    main: path.resolve(__dirname, "ComponentsInitialization.js"),
+    admin: path.resolve(__dirname, geppetto_client_path, "js/pages/admin/admin.js"),
+  };
+
+  console.log("\nThe Webpack entries are:");
   console.log(entries);
   
-    return {
-	    entry: entries,
-	  
-	    output: {
-	        path: path.resolve(__dirname, 'build'),
-	        filename: '[name].bundle.js',
-	        publicPath: publicPath
-	    },
-	    plugins: [
-	        // new BundleAnalyzerPlugin({
-	        //     analyzerMode: 'static'
-	        // }),
-		    new webpack.optimize.CommonsChunkPlugin(['common']),
-	        new CopyWebpackPlugin(availableExtensions),
-	        new HtmlWebpackPlugin({
-	            filename: 'geppetto.vm',
-	            template: path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/geppetto.ejs'),
-	            GEPPETTO_CONFIGURATION: geppettoConfig,
-	            // chunks: ['main'] Not specifying the chunk since its not possible
-				// yet (need to go to Webpack2) to specify UTF-8 as charset without
-				// which we have errors
-	            chunks: []
-	        }),
-	        new HtmlWebpackPlugin({
-	            filename: 'admin.vm',
-	            template: path.resolve(__dirname, geppetto_client_path, 'js/pages/admin/admin.ejs'),
-              GEPPETTO_CONFIGURATION: geppettoConfig,
-              // chunks: ['admin'] Not specifying the chunk since its not possible
-				// yet (need to go to Webpack2) to specify UTF-8 as charset without
-				// which we have errors
-	            chunks: []
-	        }),
-	        new HtmlWebpackPlugin({
-	            filename: 'dashboard.vm',
-	            template: path.resolve(__dirname, geppetto_client_path, 'js/pages/dashboard/dashboard.ejs'),
-	            GEPPETTO_CONFIGURATION: geppettoConfig,
-	            chunks: []
-	        }),
-	        new HtmlWebpackPlugin({
-	            filename: '../WEB-INF/web.xml',
-	            template: path.resolve(__dirname, 'WEB-INF/web.ejs'),
-	            GEPPETTO_CONFIGURATION: geppettoConfig,
-	            chunks: []
-	        }),
-	        new webpack.DefinePlugin({
-	            'process.env': {
-	                'NODE_ENV': JSON.stringify(isProduction ? 'production' : 'development'),
-              }
-	        }),
-	        new ExtractTextPlugin("[name].css"),
-	    ],
+  return {
+    entry: entries,
+    
+    output: {
+      path: path.resolve(__dirname, 'build'),
+      filename: '[name].bundle.js',
+      publicPath: publicPath
+    },
+    plugins: [
+      /*
+       * new BundleAnalyzerPlugin({
+       *     analyzerMode: 'static'
+       * }),
+       */
+      new webpack.optimize.CommonsChunkPlugin(['common']),
+      new CopyWebpackPlugin(availableExtensions),
+      new HtmlWebpackPlugin({
+        filename: 'geppetto.vm',
+        template: path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/geppetto.ejs'),
+        GEPPETTO_CONFIGURATION: geppettoConfig,
+        /*
+         * chunks: ['main'] Not specifying the chunk since its not possible
+         * yet (need to go to Webpack2) to specify UTF-8 as charset without
+         * which we have errors
+         */
+        chunks: []
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'admin.vm',
+        template: path.resolve(__dirname, geppetto_client_path, 'js/pages/admin/admin.ejs'),
+        GEPPETTO_CONFIGURATION: geppettoConfig,
+        /*
+         * chunks: ['admin'] Not specifying the chunk since its not possible
+         * yet (need to go to Webpack2) to specify UTF-8 as charset without
+         * which we have errors
+         */
+        chunks: []
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'dashboard.vm',
+        template: path.resolve(__dirname, geppetto_client_path, 'js/pages/dashboard/dashboard.ejs'),
+        GEPPETTO_CONFIGURATION: geppettoConfig,
+        chunks: []
+      }),
+      new HtmlWebpackPlugin({
+        filename: '../WEB-INF/web.xml',
+        template: path.resolve(__dirname, 'WEB-INF/web.ejs'),
+        GEPPETTO_CONFIGURATION: geppettoConfig,
+        chunks: []
+      }),
+      new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': JSON.stringify(isProduction ? 'production' : 'development'), } }),
+      new ExtractTextPlugin("[name].css"),
+    ],
       
-	    resolve: {
-	        alias: {
-              root: path.resolve(__dirname),
-              'geppetto-client': path.resolve(__dirname, geppetto_client_path),
-              geppetto: path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/GEPPETTO.js'),
-              'geppetto-client-initialization': path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/main'),
-	            handlebars: 'handlebars/dist/handlebars.js'
-	
-          },
-          // symlinks: true,
-          modules: [
-            path.resolve(__dirname, geppetto_client_path, 'node_modules'), 
-            'node_modules'
-          ],
-	        extensions: ['*', '.js', '.json'],
-	    },
-	
-	    module: {
-	        rules: [
-	            {
-	                test: /\.(js|jsx)$/,
-                  exclude: [/ami.min.js/, /node_modules\/(?!(@geppettoengine\/geppetto-client)\/).*/], 
-	                loader: 'babel-loader',
-	                query: {
-	                    presets: [['babel-preset-env', { "modules": false }], 'stage-2', 'react']
-	                }
-	            },
-	            {
-	                test: /Dockerfile/,
-	                loader: 'ignore-loader'
-	            },
-	            {
-	                test: /\.(py|jpeg|svg|gif|css|jpg|md|hbs|dcm|gz|xmi|dzi|sh|obj|yml|nii)$/,
-	                loader: 'ignore-loader'
-	            },
-	            {
-	                test: /\.(png|eot|ttf|woff|woff2|svg)(\?[a-z0-9=.]+)?$/,
-	                loader: 'url-loader?limit=100000'
-	            },
-	            {
-	                
-                  test: /\.css$/,
-	                use: ExtractTextPlugin.extract({
-	                  fallback: "style-loader",
-	                  use: "css-loader"
-	                })
-	                  
-	            },
-	            {
-                  test: /\.less$/,
-                  loader: 'style-loader!css-loader!less-loader?{"modifyVars":{"url":"\'' + path.resolve(__dirname, geppettoConfig.themes) + '\'"}}'
-	            },
-	            {
-	                test: /\.html$/,
-	                loader: 'raw-loader'
-	            }
-	        ]
-	    },
-	    node: {
-	        fs: 'empty',
-	        child_process: 'empty',
-	        module: 'empty'
-	    }
+    resolve: {
+      alias: {
+        root: path.resolve(__dirname),
+        'geppetto-client': path.resolve(__dirname, geppetto_client_path),
+        geppetto: path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/GEPPETTO.js'),
+        'geppetto-client-initialization': path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/main'),
+        handlebars: 'handlebars/dist/handlebars.js'
+  
+      },
+      // symlinks: true,
+      modules: [
+        path.resolve(__dirname, geppetto_client_path, 'node_modules'), 
+        'node_modules'
+      ],
+      extensions: ['*', '.js', '.json'],
+    },
+  
+    module: {
+      rules: [
+        {
+          test: /\.(js|jsx)$/,
+          exclude: [/ami.min.js/, /node_modules\/(?!(@geppettoengine\/geppetto-client)\/).*/], 
+          loader: 'babel-loader',
+          query: { presets: [['babel-preset-env', { "modules": false }], 'stage-2', 'react'] }
+        },
+        {
+          test: /Dockerfile/,
+          loader: 'ignore-loader'
+        },
+        {
+          test: /\.(py|jpeg|svg|gif|css|jpg|md|hbs|dcm|gz|xmi|dzi|sh|obj|yml|nii)$/,
+          loader: 'ignore-loader'
+        },
+        {
+          test: /\.(png|eot|ttf|woff|woff2|svg)(\?[a-z0-9=.]+)?$/,
+          loader: 'url-loader?limit=100000'
+        },
+        {
+                  
+          test: /\.css$/,
+          use: ExtractTextPlugin.extract({
+            fallback: "style-loader",
+            use: "css-loader"
+          })
+                    
+        },
+        {
+          test: /\.less$/,
+          loader: 'style-loader!css-loader!less-loader?{"modifyVars":{"url":"\'' + path.resolve(__dirname, geppettoConfig.themes) + '\'"}}'
+        },
+        {
+          test: /\.html$/,
+          loader: 'raw-loader'
+        }
+      ]
+    },
+    node: {
+      fs: 'empty',
+      child_process: 'empty',
+      module: 'empty'
     }
+  }
 };


### PR DESCRIPTION
Add linting:

- `build`, `build-dev`, `build-dev-noTest` and `build-dev-noTest:watch` will run ESlint  on `geppetto-application` and `geppetto-client`.
- If ESlint finds errors, the build step won't start until linting errors are removed.
- Eslint config file `.eslint.rc.js` extends the base linting configuration from `geppetto-client` linting config file. If extra linting rules need to be added, `.eslint.rc.js` can be modify and it will extend the `geppetto-client` base linting rules.
- NPM and node version had to be upgraded in `org-geppetto.frontend > pom.xml` in order for npm to understand `const`, `let` and other cmds.
- Linting rules are at a minimum in order to minimize the impact on current projects.
