### PR TITLE
Fix lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,13 @@
   "repository": "http://git.geppetto.org",
   "license": "MIT",
   "scripts": {
-    "prebuild": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "prebuild": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build": "webpack -p --progress",
-    "prebuild-dev": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "prebuild-dev": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev": "webpack --devtool eval",
-    "prebuild-dev-noTest": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "prebuild-dev-noTest": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev-noTest": "webpack --devtool source-map --env.noTest=true",
-    "prebuild-dev-noTest:watch": "eslint --ignore-pattern 'node_modules/*' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
+    "prebuild-dev-noTest:watch": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev-noTest:watch": "webpack --devtool source-map --env.noTest=true --progress --watch",
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,15 @@
         "sourceMap": true,
         "noImplicitAny": true,
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "stripInternal":true,
         "alwaysStrict":true,
         "forceConsistentCasingInFileNames": true,
         "noImplicitReturns": true,
         "strict": true,
         "noUnusedLocals": true,
-        "jsx": "react"
+        "jsx": "react",
+        "types": []
       },
       "include": [
         "./node_modules/@geppettoengine/geppetto-client/js/components/interface/flexLayout2/src/**/*", "./@geppettoengine/geppetto-client/js/components/interface/flexLayout2/examples/demo/*"


### PR DESCRIPTION
When geppetto-client is installed in development mode in `webapp/geppetto-client` then `webapp/geppetto-client/node_modules` folder has to be ignored for linting