### PR TITLE
Use "file" key in package.json to avoid "npm link" in development

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,11 +121,6 @@ module.exports = function (env){
         'geppetto-client-initialization': path.resolve(__dirname, geppetto_client_path, 'js/pages/geppetto/main'),
         handlebars: 'handlebars/dist/handlebars.js'
       },
-      modules: [
-        path.resolve(__dirname, 'geppetto-client', 'node_modules'),
-        path.resolve(__dirname, geppetto_client_path, 'node_modules'), 
-        'node_modules'
-      ],
       extensions: ['*', '.js', '.json', '.ts', '.tsx', '.jsx'],
     },
   


### PR DESCRIPTION
Closes #16 
Bound to https://github.com/openworm/org.geppetto.docs/pull/80.

The issue related to webpack not being able to pick the right version of a package when we install `geppetto-client` in development mode can be addressed by implementing a different approach.

Instead of using `npm link`, do the following:

Clone geppetto-client inside geppetto-application and then use local file dependencies in package.json as follow:

```json
// package.json
"devDependencies": {
    "@geppettoengine/geppetto-client": "file:./geppetto-client"
  },
```

That will cause `mvn install` to preserve symlinks and to avoid the node_module folder duplication. 

That is all that it needs to be done. After that, you can run `npm start` and go to localhost:8081 and work in de development. No need to link or run any sequence of steps.

cc: @ddelpiano, @jrmartin, @tarelli 