### PR TITLE
Feature/geppetto client 42

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,26 @@
     "prestart": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "@geppettoengine/geppetto-client": "file:geppetto-client",
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "copy-webpack-plugin": "^4.6.0",
+    "css-loader": "^3.0.0",
+    "exports-loader": "^0.6.3",
+    "html-webpack-plugin": "^3.2.0",
+    "ignore-loader": "^0.1.2",
+    "imports-loader": "^0.7.1",
+    "less-loader": "^5.0.0",
+    "mini-css-extract-plugin": "^0.7.0",
+    "style-loader": "^0.13.2",
+    "url-loader": "^0.5.8",
+    "webpack": "^4.35.0",
+    "webpack-cli": "^3.3.5"
+  },
+  "devDependencies": {
     "@babel/preset-stage-2": "^7.0.0",
     "@types/jasmine": "^2.8.8",
     "@types/material-ui": "^0.21.5",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "http://git.geppetto.org",
   "license": "MIT",
   "scripts": {
-    "prebuild": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build": "webpack -p --progress --mode none",
     "prebuild-dev": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev": "webpack --mode none --devtool eval",
@@ -17,7 +16,25 @@
     "start": "node --max_old_space_size=2048 node_modules/webpack-dev-server/bin/webpack-dev-server.js --progress  --config webpack.config.dev.js"
   },
   "devDependencies": {
-    "@geppettoengine/geppetto-client": "file:./geppetto-client"
+    "@geppettoengine/geppetto-client": "file:geppetto-client",
+    "@babel/preset-stage-2": "^7.0.0",
+    "@types/jasmine": "^2.8.8",
+    "@types/material-ui": "^0.21.5",
+    "@types/react": "^16.4.9",
+    "@types/react-dom": "^16.0.7",
+    "awesome-typescript-loader": "^3.5.0",
+    "babel-eslint": "^10.0.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.5",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "eslint": "^6.0.1",
+    "jasmine": "^3.2.0",
+    "json-loader": "^0.5.4",
+    "raw-loader": "^0.5.1",
+    "source-map-loader": "^0.2.3",
+    "typedoc": "^0.11.1",
+    "typescript": "^2.0.0",
+    "webpack-dev-server": "^3.7.2"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "http://git.geppetto.org",
   "license": "MIT",
   "scripts": {
+    "prebuild": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build": "webpack -p --progress --mode none",
     "prebuild-dev": "eslint --ignore-pattern 'node_modules/*' --ignore-pattern 'geppetto-client/node_modules' . --color ; eslint ./node_modules/@geppettoengine/geppetto-client/js/**/*.js --color",
     "build-dev": "webpack --mode none --devtool eval",


### PR DESCRIPTION
Relates with: https://github.com/openworm/geppetto-client/pull/83

- Brings Geppetto-Client dependencies needed for building the application to both Geppetto-Application dependencies and devDependencies.
- Moves Geppetto-Client from devDependency to dependency.