### PR TITLE
Fix/49

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,8 @@ module.exports = {
   "preset": "jest-puppeteer",
   "testRegex": "(tests/jest-puppeteer/Test.*|(\\.|/)(test|spec))\\.[jt]sx?$",
   "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/geppetto-client/",
-      "<rootDir>/geppetto-client/__tests__/"
-    ]
+    "<rootDir>/node_modules/",
+    "<rootDir>/geppetto-client/",
+    "<rootDir>/geppetto-client/__tests__/"
+  ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,8 @@
-module.exports = { 
-  "preset": "jest-puppeteer", 
-  "testRegex": "(/tests/jest-puppeteer/Test.*|(\\.|/)(test|spec))\\.[jt]sx?$"
+module.exports = {
+  "preset": "jest-puppeteer",
+  "testRegex": "(tests/jest-puppeteer/Test.*|(\\.|/)(test|spec))\\.[jt]sx?$",
+  "testPathIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/geppetto-client/__tests__/*"
+    ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   "preset": "jest-puppeteer",
   "testRegex": "(tests/jest-puppeteer/Test.*|(\\.|/)(test|spec))\\.[jt]sx?$",
   "testPathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/geppetto-client/__tests__/*"
+      "<rootDir>/node_modules/",
+      "<rootDir>/geppetto-client/",
+      "<rootDir>/geppetto-client/__tests__/"
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -859,6 +859,7 @@
         "@material-ui/core": "^4.1.3",
         "@material-ui/pickers": "^3.1.2",
         "anchorme": "^0.7.1",
+        "babel-jest": "^24.9.0",
         "babel-polyfill": "^6.26.0",
         "backbone": "^1.3.3",
         "backbone-associations": "^0.6.2",
@@ -926,7 +927,7 @@
         "three": "^0.87.0",
         "typeahead.js": "^0.11.1",
         "typeface-roboto": "^0.0.54",
-        "underscore": "^1.8.3",
+        "underscore": "~1.9.1",
         "url-join": "^4.0.0",
         "velocity.java": "^1.3.1"
       }

--- a/tests/jest-puppeteer/TestLiveGeppetto.js
+++ b/tests/jest-puppeteer/TestLiveGeppetto.js
@@ -9,7 +9,7 @@ import {
 
 import * as ST from './selectors';
 
-const baseURL = getCommandLineArg('--url', 'http://live.geppetto.org');
+const baseURL = process.env.url ||  'http://live.geppetto.org';
 
 describe('Test live.geppetto.org', () => {
     beforeAll(async () => {

--- a/tests/jest-puppeteer/TestUIComponents.js
+++ b/tests/jest-puppeteer/TestUIComponents.js
@@ -7,7 +7,7 @@ import { wait4selector, click } from './utils';
 import * as ST from './selectors';
 
 const COLLAPSE_WIDGET_HEIGHT = 35;
-const baseURL = getCommandLineArg('--url', 'http://localhost:8080/org.geppetto.frontend');
+const baseURL = process.env.url ||  'http://localhost:8080/org.geppetto.frontend';
 
 describe('Test UI Components', () => {
   beforeAll(async () => {
@@ -16,7 +16,7 @@ describe('Test UI Components', () => {
     await page.goto(baseURL);
   });
 
-  
+
   describe('Test Dashboard', () => {
     const PROJECT_IDS = [1, 3, 4, 5, 6, 8, 9, 16, 18, 58];
     it.each(PROJECT_IDS)('Project width id %i from core bundle are present', async id => {
@@ -35,12 +35,12 @@ describe('Test UI Components', () => {
       it("Spinner goes away", async () => {
         await wait4selector(page, ST.SPINNER_SELECTOR, { hidden: true })
       })
-      
+
       it.each(ST.ELEMENTS_IN_LANDING_PAGE)('%s', async (msg, selector) => {
         await wait4selector(page, selector, { visible: true })
       })
-       
-    }) 
+
+    })
 
 
     describe('Console', () => {
@@ -48,12 +48,12 @@ describe('Test UI Components', () => {
         await click(page, ST.CONSOLE_SELECTOR)
         await wait4selector(page, ST.DRAWER_SELECTOR, { visible: true });
       })
-      
+
       it('The console panel is correctly hidden.', async () => {
         await click(page, ST.DRAWER_MINIMIZE_ICON_SELECTOR);
         await wait4selector(page, ST.DRAWER_SELECTOR, { hidden: true });
       })
-      
+
       it('Console is maximized correctly.', async () => {
         await click(page, ST.CONSOLE_SELECTOR)
         await wait4selector(page, ST.DRAWER_SELECTOR, { visible: true });
@@ -62,7 +62,7 @@ describe('Test UI Components', () => {
           await page.evaluate( async selector => $(selector).height() > 250, ST.DRAWER_CONTAINER_SELECTOR)
         ).toBeTruthy()
       })
-      
+
       it('Console output empty.', async () => {
         await click(page, ST.DRAWER_CLOSE_ICON_SELECTOR)
         await wait4selector(page, ST.DRAWER_SELECTOR, { hidden: true });
@@ -101,7 +101,7 @@ describe('Test UI Components', () => {
       })
     })
 
-    
+
     describe('Debug mode functionality', () => {
       it('Debug mode disabled.', async () => {
         expect(
@@ -151,7 +151,7 @@ describe('Test UI Components', () => {
           await page.evaluate(async () => G.help())
         ).not.toBeNull()
       })
-        
+
       it("I've waited for help window to go away.", async () => {
         await page.evaluate(async selector => $(selector).find("button")[0].click(), ST.HELP_MODAL_SELECTOR)
         await wait4selector(page, ST.HELP_MODAL_SELECTOR, { hidden: true });
@@ -170,27 +170,27 @@ describe('Test UI Components', () => {
           await page.evaluate( async widgetName => eval(widgetName).getSize(), widgetName)
         ).toEqual(originalDimensions)
       })
-      
+
 
       describe('Maximize', () => {
         beforeAll(async () => {
           await page.evaluate( async selector => $(selector).parent().find("a")[2].click(), `#${widgetName}`)
         });
-          
+
         it('Maximized dimensions are correct.', async () => {
           const widgetDimensions = await page.evaluate( async widgetName => {
             const parent = eval(widgetName).$el.parent()
             return { width: Math.round(parent.width()), height: Math.round(parent.height()) }
           }, widgetName)
 
-          const widgetExpectedDimensions = await page.evaluate( async () => ({ 
+          const widgetExpectedDimensions = await page.evaluate( async () => ({
             width: Math.round($(window).width()-.2),
             height: Math.round($(window).height() - 5.2)
           }))
 
           expect(widgetDimensions).toEqual(widgetExpectedDimensions);
         })
-        
+
         it('Restored dimensions are correct.', async () => {
           await page.evaluate( async selector => $(selector).parent().find("a")[2].click(), `#${widgetName}`);
           expect(
@@ -213,7 +213,7 @@ describe('Test UI Components', () => {
             await page.evaluate( async selector => $(selector).find(".ui-dialog").length, ST.MINIMIZE_WIDGETS_CONTAINER_SELECTOR)
           ).toBe(1)
         })
-        
+
         it('Restored correctly.', async () => {
           await page.evaluate( async selector => $(selector).parent().find("a")[3].click(), `#${widgetName}`);
           expect(
@@ -231,14 +231,14 @@ describe('Test UI Components', () => {
         })
 
         it('Collapse correctly.', async () => {
-          await page.evaluate( async selector => $(selector).parent().find("a")[0].click(), `#${widgetName}`);  
+          await page.evaluate( async selector => $(selector).parent().find("a")[0].click(), `#${widgetName}`);
           expect(
             await page.evaluate(async (widgetID, height) => $(widgetID).height() < height, `#${widgetName}`, COLLAPSE_WIDGET_HEIGHT)
           ).toBeTruthy()
         })
 
         it('Resotored correctly.', async () => {
-          await page.evaluate( async selector => $(selector).parent().find("a")[1].click(), `#${widgetName}`);  
+          await page.evaluate( async selector => $(selector).parent().find("a")[1].click(), `#${widgetName}`);
           expect(
             await page.evaluate(async (widgetID, height) => $(widgetID).height() < height, `#${widgetName}`, COLLAPSE_WIDGET_HEIGHT)
           ).toBeFalsy()
@@ -260,7 +260,7 @@ describe('Test UI Components', () => {
         await page.evaluate( async () => G.addWidget(0))
         await wait4selector(page, '#Plot1', { visible: true });
       });
-      
+
       it("'S / m2' unit.", async () => {
         expect(
           await page.evaluate( async () => Plot1.getUnitLabel("S / m2"))

--- a/tests/jest-puppeteer/cmdline.js
+++ b/tests/jest-puppeteer/cmdline.js
@@ -3,7 +3,7 @@ const urljoin = require('url-join');
 
 export const getCommandLineArg = (param, defaultValue) => {
   let value = process.argv.find(arg => arg.startsWith(param))
-  
+
   if (value) {
     return value.replace(`${param}=`, '')
   } else {
@@ -11,8 +11,8 @@ export const getCommandLineArg = (param, defaultValue) => {
   }
 }
 
-export const baseURL = getCommandLineArg('--url', 'http://localhost:8080/org.geppetto.frontend');
 
+export const baseURL = process.env.url ||  'http://localhost:8080/org.geppetto.frontend';
 const getFullPath = (relativePath = 'geppetto?') => urljoin(baseURL, relativePath);
 
 export const getUrlFromProjectId = (id = undefined) => urljoin(baseURL, 'geppetto?') + (id ? `load_project_from_id=${id}` : '');

--- a/tests/jest-puppeteer/persistence/TestPersistence.js
+++ b/tests/jest-puppeteer/persistence/TestPersistence.js
@@ -4,7 +4,7 @@ import { wait4selector, click } from './../utils';
 import { testProject, testCreateExperiment, testCloneExperiment, testDeleteExperiment, testSaveProjectProperties, testSaveExperimentProperties } from './persistence_functions';
 import * as ST from './../selectors';
 
-const baseURL = getCommandLineArg('--url', 'http://localhost:8080/org.geppetto.frontend/');
+const baseURL = process.env.url ||  'http://localhost:8080/org.geppetto.frontend';
 
 const PERSISTENCE_PROJECT_1 = {
 		name : "Hodgkin-Huxley Neuron",
@@ -83,21 +83,21 @@ describe('Test Persistence', () => {
 })
 
 /**
- * Test loading first project, and then persisting it. 
+ * Test loading first project, and then persisting it.
  */
 describe('Test First Project', () => {
 	testProject(page,baseURL, true, PERSISTENCE_PROJECT_1);
 })
 
 /**
- * Test loading second project, and then persisting it. 
+ * Test loading second project, and then persisting it.
  */
 describe('Test Second Project', () => {
 	testProject(page,baseURL, false, PERSISTENCE_PROJECT_2);
 })
 
 /**
- * Test loading third project, and then persisting it. 
+ * Test loading third project, and then persisting it.
  */
 describe('Test Third Project', () => {
 	testProject(page,baseURL, false, PERSISTENCE_PROJECT_3);
@@ -107,7 +107,7 @@ describe('Test Third Project', () => {
  * Test persistence features: creating, cloning and deleting experiments, saving project and experiment.
  */
 describe('Test Persistence Features', () => {
-	beforeAll(async () => {		
+	beforeAll(async () => {
 		jest.setTimeout(100000);
 		//Load persisted project with ID 1
 		await page.goto(getUrlFromProjectId(1));
@@ -174,7 +174,7 @@ describe('Test Persistence Features', () => {
 		});
 
 		//Save project and experiment properties
-		describe('Test Saving Project and Experiment Properties',  () => {			
+		describe('Test Saving Project and Experiment Properties',  () => {
 			const experiment_properties = {"name": "Experiment Test",
 					"conversionServiceId" : "testService",
 					"simulatorId" : "testSimulator",
@@ -184,7 +184,7 @@ describe('Test Persistence Features', () => {
 
 			const project_properties = {"name": "New Project Name"};
 			it('Save Project and Experiment', async () => {
-				await page.evaluate(async (project_properties, experiment_properties) => { 
+				await page.evaluate(async (project_properties, experiment_properties) => {
 					window.Project.getExperiments()[(window.Project.getExperiments().length-1)].saveExperimentProperties(experiment_properties);
 					window.Project.saveProjectProperties(project_properties);
 				}, project_properties, experiment_properties)


### PR DESCRIPTION
- Fix jest puppeter tests ignoring whatever unit tests has been implemented within geppetto-client (not supposed to run along the geppetto-application tests).
- changed the baseURL parameter retrieval
